### PR TITLE
Fixing the destroy heap synchronization issue

### DIFF
--- a/include/nvmm/error_code.h
+++ b/include/nvmm/error_code.h
@@ -25,18 +25,17 @@
 #ifndef _NVMM_ERROR_CODE_H_
 #define _NVMM_ERROR_CODE_H_
 
-namespace nvmm{
-enum ErrorCode
-{
+namespace nvmm {
+enum ErrorCode {
     // general errors (0-)
-    NO_ERROR=0,
+    NO_ERROR = 0,
     NOT_YET_IMPLEMENTED,
     BUG,
     OUT_OF_MEMORY,
     INVALID_ARGUMENTS, // one or more of the argument to the function is invalid
 
     // shelf file (20-)
-    SHELF_FILE_CREATE_FAILED=20,
+    SHELF_FILE_CREATE_FAILED = 20,
     SHELF_FILE_DESTROY_FAILED,
     SHELF_FILE_TRUNCATE_FAILED,
     SHELF_FILE_OPEN_FAILED,
@@ -46,21 +45,21 @@ enum ErrorCode
     SHELF_FILE_UNMAP_FAILED,
     SHELF_FILE_FOUND,
     SHELF_FILE_NOT_FOUND,
-    SHELF_FILE_RENAME_FAILED=30,
-    
-    SHELF_FILE_FORMAT_FAILED, 
+    SHELF_FILE_RENAME_FAILED = 30,
+
+    SHELF_FILE_FORMAT_FAILED,
     SHELF_FILE_CLEAR_FAILED, // clear the formatting
     SHELF_FILE_VERIFY_FAILED,
     SHELF_FILE_INVALID_FORMAT,
     SHELF_FILE_RECOVER_FAILED,
     SHELF_FILE_GET_PERM_FAILED,
     SHELF_FILE_SET_PERM_FAILED,
-    
+
     SHELF_FILE_OPENED,
     SHELF_FILE_CLOSED,
-    
+
     // pool (60-)
-    POOL_CREATE_FAILED=60,
+    POOL_CREATE_FAILED = 60,
     POOL_DESTROY_FAILED,
     POOL_VERIFY_FAILED,
     POOL_OPEN_FAILED,
@@ -80,13 +79,12 @@ enum ErrorCode
     POOL_CLOSED,
 
     // membership (80-)
-    MEMBERSHIP_CREATE_FAILED=80,
+    MEMBERSHIP_CREATE_FAILED = 80,
     MEMBERSHIP_DESTROY_FAILED,
     MEMBERSHIP_OPEN_FAILED,
-    
-    
+
     // Heap (100-)
-    HEAP_CREATE_FAILED=100,
+    HEAP_CREATE_FAILED = 100,
     HEAP_DESTROY_FAILED,
     HEAP_OPEN_FAILED,
     HEAP_CLOSE_FAILED,
@@ -96,44 +94,45 @@ enum ErrorCode
     HEAP_RESIZE_FAILED,
     HEAP_SET_PERMISSION_FAILED,
     HEAP_GET_PERMISSION_FAILED,
-    HEAP_BUSY,  // Some other metadata operation in progress
+    HEAP_BUSY, // Some other metadata operation in progress
     HEAP_NOT_OPEN,
     HEAP_IS_OPEN,
-    
+
     // Region (120-)
-    REGION_CREATE_FAILED=120,
+    REGION_CREATE_FAILED = 120,
     REGION_DESTROY_FAILED,
     REGION_OPEN_FAILED,
-    REGION_CLOSE_FAILED,    
+    REGION_CLOSE_FAILED,
     REGION_MAP_FAILED,
     REGION_UNMAP_FAILED,
     REGION_OPENED,
     REGION_CLOSED,
 
     // FreeLists (140-)
-    FREELISTS_CREATE_FAILED=140,
+    FREELISTS_CREATE_FAILED = 140,
     FREELISTS_DESTROY_FAILED,
     FREELISTS_OPEN_FAILED,
     FREELISTS_PUT_FAILED,
     FREELISTS_EMPTY,
-    
+
     // Ownership (150-)
-    OWNERSHIP_CREATE_FAILED=150,
+    OWNERSHIP_CREATE_FAILED = 150,
     OWNERSHIP_DESTROY_FAILED,
     OWNERSHIP_OPEN_FAILED,
-    
+
     // memory manager (200-)
-    ID_FOUND=200, // this id is in use
-    ID_NOT_FOUND, // this id is available
+    ID_FOUND = 200, // this id is in use
+    ID_NOT_FOUND,   // this id is available
     INVALID_PTR,
     MAP_POINTER_FAILED,
-    
-    
+
+    // shelf manager (250-)
+    SHELF_ID_NOT_FOUND = 250,
+
     // max return code
     MAX_RETURN_CODE
 };
 
 } // namespace nvmm
-
 
 #endif

--- a/include/nvmm/heap.h
+++ b/include/nvmm/heap.h
@@ -25,46 +25,47 @@
 #ifndef _NVMM_HEAP_H_
 #define _NVMM_HEAP_H_
 
+#include "nvmm/epoch_manager.h"
 #include "nvmm/error_code.h"
 #include "nvmm/global_ptr.h"
-#include "nvmm/epoch_manager.h"
 
 namespace nvmm {
 
-class Heap
-{
-public:
+class Heap {
+  public:
     virtual ~Heap(){};
 
     virtual ErrorCode Open() = 0;
     virtual ErrorCode Close() = 0;
     virtual bool IsOpen() = 0;
+    virtual bool IsInvalid() = 0;
 
-    virtual ErrorCode Map (Offset offset, size_t size, void *addr_hint, int prot, void **mapped_addr) = 0;
-    virtual ErrorCode Unmap (Offset offset, void *mapped_addr, size_t size) = 0;
+    virtual ErrorCode Map(Offset offset, size_t size, void *addr_hint, int prot,
+                          void **mapped_addr) = 0;
+    virtual ErrorCode Unmap(Offset offset, void *mapped_addr, size_t size) = 0;
 
-    virtual GlobalPtr Alloc (size_t size) = 0;
-    virtual void Free (GlobalPtr global_ptr) = 0;
+    virtual GlobalPtr Alloc(size_t size) = 0;
+    virtual void Free(GlobalPtr global_ptr) = 0;
 
-    virtual GlobalPtr Alloc (EpochOp &op, size_t size){return (GlobalPtr)0;};
-    virtual void Free (EpochOp &op, GlobalPtr global_ptr){};
+    virtual GlobalPtr Alloc(EpochOp &op, size_t size) { return (GlobalPtr)0; };
+    virtual void Free(EpochOp &op, GlobalPtr global_ptr){};
 
     // Functions for Offset based free and alloc function
-    virtual Offset AllocOffset (size_t size){return 0;};
+    virtual Offset AllocOffset(size_t size) { return 0; };
     virtual void Free(Offset offset){};
 
-    virtual ErrorCode Resize (size_t size) = 0;
-    virtual ErrorCode SetPermission (mode_t mode) = 0;
-    virtual ErrorCode GetPermission (mode_t *mode) = 0;
+    virtual ErrorCode Resize(size_t size) = 0;
+    virtual ErrorCode SetPermission(mode_t mode) = 0;
+    virtual ErrorCode GetPermission(mode_t *mode) = 0;
 
-    virtual void *OffsetToLocal(Offset offset){return NULL;};
-    virtual size_t MinAllocSize(){return 0;};
-    virtual void Merge (){};
-    virtual void OfflineRecover (){};
-    virtual void OnlineRecover (){};
-    virtual void Stats (){};
-    virtual size_t Size () {return 0;};
-    virtual void OfflineFree (){};
+    virtual void *OffsetToLocal(Offset offset) { return NULL; };
+    virtual size_t MinAllocSize() { return 0; };
+    virtual void Merge(){};
+    virtual void OfflineRecover(){};
+    virtual void OnlineRecover(){};
+    virtual void Stats(){};
+    virtual size_t Size() { return 0; };
+    virtual void OfflineFree(){};
 };
 
 } // namespace nvmm

--- a/src/allocator/dist_heap.h
+++ b/src/allocator/dist_heap.h
@@ -25,39 +25,41 @@
 #ifndef _NVMM_DIST_HEAP_H_
 #define _NVMM_DIST_HEAP_H_
 
+#include <map>
+#include <mutex>
+#include <pthread.h> // the reader-writer lock
 #include <stddef.h>
 #include <stdint.h>
 #include <thread>
-#include <mutex>
-#include <pthread.h> // the reader-writer lock
-#include <map>
 
 #include "nvmm/error_code.h"
-#include "nvmm/global_ptr.h"
-#include "nvmm/shelf_id.h"
 #include "nvmm/fam.h"
+#include "nvmm/global_ptr.h"
 #include "nvmm/heap.h"
+#include "nvmm/shelf_id.h"
 
 #include "shelf_mgmt/pool.h"
 
-namespace nvmm{
+namespace nvmm {
 
 class Ownership;
-class FreeLists;    
+class FreeLists;
 class ShelfHeap;
-    
+
 // distributed/hierarchical heap
-// - it relies on Pool to manage shelf membership; every shelf in the pool is a single-shelf heap
-// - it manages heap ownership by itself; a process owns one or more single-shelf heaps
-// - there is a backbround thread (per process) scanning freelists of the heaps the process owns and
-// freeing space; the background thread also performs crash recovery for the distributed heap
+// - it relies on Pool to manage shelf membership; every shelf in the pool is a
+// single-shelf heap
+// - it manages heap ownership by itself; a process owns one or more
+// single-shelf heaps
+// - there is a backbround thread (per process) scanning freelists of the heaps
+// the process owns and freeing space; the background thread also performs crash
+// recovery for the distributed heap
 // TODO: handle single-shelf heap crash recovery?
 // TODO: have a background thread to periodically call Pool::Recover()???
-class DistHeap : public Heap
-{
-public:
+class DistHeap : public Heap {
+  public:
     DistHeap() = delete;
-    DistHeap(PoolId pool_id);    
+    DistHeap(PoolId pool_id);
     ~DistHeap();
 
     // TODO: size is not used for now
@@ -67,33 +69,34 @@ public:
 
     ErrorCode Open();
     ErrorCode Close();
-    bool IsOpen()
-    {
-        return is_open_;
-    }
-    
-    GlobalPtr Alloc (size_t size);
-    void Free (GlobalPtr global_ptr);
+    bool IsOpen() { return is_open_; }
+
+    bool IsInvalid() { return is_invalid_; }
+
+    GlobalPtr Alloc(size_t size);
+    void Free(GlobalPtr global_ptr);
 
     // only for testing
-    void *GlobalToLocal(GlobalPtr global_ptr);    
+    void *GlobalToLocal(GlobalPtr global_ptr);
     // TODO: not yet implemented
-    //GlobalPtr LocalToGlobal(void *addr);
-    
-private:
-    static size_t const kShelfSize = Pool::kShelfSize; // for now, all shelves are of the same size
-    static ShelfIndex const kMaxShelfCount = Pool::kMaxShelfCount; 
+    // GlobalPtr LocalToGlobal(void *addr);
+
+  private:
+    static size_t const kShelfSize =
+        Pool::kShelfSize; // for now, all shelves are of the same size
+    static ShelfIndex const kMaxShelfCount = Pool::kMaxShelfCount;
     static uint64_t const kWorkerSleepMicroSeconds = 500000;
-    static ShelfIndex const kMaxOwnedHeap = 1; // max number of heaps one process can own
-    
+    static ShelfIndex const kMaxOwnedHeap =
+        1; // max number of heaps one process can own
+
     // start/stop the background cleaner
     int StartWorker();
     int StopWorker();
     void BackgroundWorker();
 
     // helper functions to own/release a single-shelf heap
-    // newonly == false: try to find an existing heap first before creating a new heap
-    // newonly == true: always create a new heap
+    // newonly == false: try to find an existing heap first before creating a
+    // new heap newonly == true: always create a new heap
     bool AcquireShelfHeap(ShelfIndex &shelf_idx, bool newonly);
     bool ReleaseShelfHeap(ShelfIndex shelf_idx);
 
@@ -101,44 +104,35 @@ private:
     ErrorCode OpenShelfHeap(ShelfIndex shelf_idx);
     ErrorCode CloseShelfHeap(ShelfIndex shelf_idx);
     ErrorCode RecoverShelfHeap(ShelfIndex shelf_idx);
-    
+
     // helper functions to add/remove/lookup map_
     ShelfHeap *LookupShelfHeap(ShelfIndex shelf_idx);
     bool RegisterShelfHeap(ShelfIndex shelf_idx, ShelfHeap *shelf_heap);
     bool UnregisterShelfHeap(ShelfIndex shelf_idx);
-    
-    inline void ReadLock()
-    {
-        pthread_rwlock_rdlock(&rwlock_);
-    }
 
-    inline void ReadUnlock()
-    {
-        pthread_rwlock_unlock(&rwlock_);
-    }
+    inline void ReadLock() { pthread_rwlock_rdlock(&rwlock_); }
 
-    inline void WriteLock()
-    {
-        pthread_rwlock_wrlock(&rwlock_);
-    }
+    inline void ReadUnlock() { pthread_rwlock_unlock(&rwlock_); }
 
-    inline void WriteUnlock()
-    {
-        pthread_rwlock_unlock(&rwlock_);
-    }
-    
+    inline void WriteLock() { pthread_rwlock_wrlock(&rwlock_); }
+
+    inline void WriteUnlock() { pthread_rwlock_unlock(&rwlock_); }
+
     // pool
     PoolId pool_id_;
     Pool pool_;
     bool is_open_;
+    bool is_invalid_;
 
     // heap metadata
     Ownership *ownership_;
     FreeLists *freelists_;
-    
-    pthread_rwlock_t rwlock_; // protecting the mapping and the current active heap
-    std::map<ShelfIndex, ShelfHeap*> map_; // for heaps that we own: ShelfIndex => ShelfHeap
-    
+
+    pthread_rwlock_t
+        rwlock_; // protecting the mapping and the current active heap
+    std::map<ShelfIndex, ShelfHeap *>
+        map_; // for heaps that we own: ShelfIndex => ShelfHeap
+
     // for the background cleaner thread
     std::thread cleaner_thread_;
     std::mutex cleaner_mutex_;
@@ -146,8 +140,8 @@ private:
     bool cleaner_stop_;
 
     // TODO: gather freespace stats
-    //size_t capacity_[ShelfIdMap::kMaxShelfCount];
-    //size_t freespace_[ShelfIdMap::kMaxShelfCount];
+    // size_t capacity_[ShelfIdMap::kMaxShelfCount];
+    // size_t freespace_[ShelfIdMap::kMaxShelfCount];
 };
 
 } // namespace nvmm

--- a/src/allocator/epoch_zone_heap.cc
+++ b/src/allocator/epoch_zone_heap.cc
@@ -25,21 +25,21 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <string>
 #include <assert.h>
+#include <string>
 
 #include "nvmm/error_code.h"
-#include "nvmm/global_ptr.h"
-#include "nvmm/shelf_id.h"
-#include "nvmm/heap.h"
 #include "nvmm/fam.h"
-#include "nvmm/memory_manager.h"
+#include "nvmm/global_ptr.h"
+#include "nvmm/heap.h"
 #include "nvmm/log.h"
+#include "nvmm/memory_manager.h"
+#include "nvmm/shelf_id.h"
 
 #include "shelf_mgmt/pool.h"
 
-#include "shelf_usage/zone_shelf_heap.h"
 #include "shelf_usage/shelf_region.h"
+#include "shelf_usage/zone_shelf_heap.h"
 
 #include "nvmm/epoch_manager.h"
 
@@ -47,86 +47,77 @@
 
 namespace nvmm {
 
-#define CHECK_IS_CLOSED()                                  \
-if (IsOpen() == true) {                                    \
-       LOG(error) <<"Heap is already open";                \
-       return HEAP_IS_OPEN;                                \
-}
+#define CHECK_IS_CLOSED()                                                      \
+    if (IsOpen() == true) {                                                    \
+        LOG(error) << "Heap is already open";                                  \
+        return HEAP_IS_OPEN;                                                   \
+    }
 
+#define CHECK_IS_OPEN()                                                        \
+    if (IsOpen() != true) {                                                    \
+        LOG(error) << "Heap is not open";                                      \
+        return HEAP_NOT_OPEN;                                                  \
+    }
 
-#define CHECK_IS_OPEN()                              \
-if (IsOpen() != true) {                                    \
-       LOG(error) <<"Heap is not open";                    \
-       return HEAP_NOT_OPEN;                               \
-}
+#define ASSERT_IS_CLOSED() assert(IsOpen() != true);
+#define ASSERT_IS_OPEN() assert(IsOpen() == true);
 
-#define ASSERT_IS_CLOSED()  assert (IsOpen() != true);
-#define ASSERT_IS_OPEN()  assert (IsOpen() == true);
-
-//If LFS_BOOK_SIZE is not passed, set it to 8GB.
+// If LFS_BOOK_SIZE is not passed, set it to 8GB.
 #ifndef LFS_BOOK_SIZE
-#define LFS_BOOK_SIZE (8*1024*1024*1024UL)
+#define LFS_BOOK_SIZE (8 * 1024 * 1024 * 1024UL)
 #endif
 
-inline uint64_t power_of_two(uint64_t n)
-{
-        uint64_t power = 0;
-        if (n == 0) {
-                return 0;
+inline uint64_t power_of_two(uint64_t n) {
+    uint64_t power = 0;
+    if (n == 0) {
+        return 0;
+    }
+    while (n != 1) {
+        if (n % 2 != 0) {
+            return 0;
         }
-        while (n != 1) {
-                if (n % 2 != 0) {
-                        return 0;
-                }
-                n = n >> 1;
-                power = power + 1;
-        }
-        return power;
+        n = n >> 1;
+        power = power + 1;
+    }
+    return power;
 }
 
-inline bool is_power_of_two(uint64_t n)
-{
-        return ((n != 0) && !(n & (n-1)));
+inline bool is_power_of_two(uint64_t n) { return ((n != 0) && !(n & (n - 1))); }
+
+inline uint64_t next_power_of_two(uint64_t n) {
+    if (is_power_of_two(n)) {
+        return n;
+    } else {
+        n |= n >> 1;
+        n |= n >> 2;
+        n |= n >> 4;
+        n |= n >> 8;
+        n |= n >> 16;
+        n |= n >> 32;
+        return n + 1;
+    }
 }
 
-inline uint64_t next_power_of_two(uint64_t n)
-{
-        if (is_power_of_two(n)) {
-                return n;
-        } else {
-                n |= n >> 1;
-                n |= n >> 2;
-                n |= n >> 4;
-                n |= n >> 8;
-                n |= n >> 16;
-                n |= n >> 32;
-                return n + 1;
-        }
-}
-
-
-// 
+//
 // There is a bug in current LFS code, which does not mmap from right offset.
-// Bug: mmap from any offset incorrectly mmaps from boundaries of Book size 
+// Bug: mmap from any offset incorrectly mmaps from boundaries of Book size
 // (8GB default).
 //
 // So we create header's in case of LFS as the multiple of 8GB (Book size).
 // Header extention in case of a Resize also will be multiple of 8GB(Book size).
 //
-inline size_t header_size_round_up () {
+inline size_t header_size_round_up() {
 #ifdef LFSWORKAROUND
-   return round_up(LFS_BOOK_SIZE, getpagesize());
+    return round_up(LFS_BOOK_SIZE, getpagesize());
 #else
-   return getpagesize();
+    return getpagesize();
 #endif
 }
 
-
 EpochZoneHeap::EpochZoneHeap(PoolId pool_id)
-    : gh_{ NULL }, pool_id_{ pool_id }, pool_{ pool_id }, rmb_size_{ 0 }, rmb_{ NULL },
-      region_{ NULL }, mapped_addr_{ NULL }, header_{ NULL },
-      is_open_{ false }, cleaner_start_{ false }, cleaner_stop_{ false },
-      cleaner_running_{ false } {}
+    : gh_{NULL}, pool_id_{pool_id}, pool_{pool_id}, rmb_size_{0}, rmb_{NULL},
+      region_{NULL}, mapped_addr_{NULL}, header_{NULL}, is_open_{false},
+      cleaner_start_{false}, cleaner_stop_{false}, cleaner_running_{false} {}
 
 EpochZoneHeap::~EpochZoneHeap() {
     if (IsOpen() == true) {
@@ -135,8 +126,8 @@ EpochZoneHeap::~EpochZoneHeap() {
 }
 
 // Creates a heap with size next power of two of the passed size
-ErrorCode EpochZoneHeap::Create(size_t shelf_size, size_t min_alloc_size, mode_t mode)
-{
+ErrorCode EpochZoneHeap::Create(size_t shelf_size, size_t min_alloc_size,
+                                mode_t mode) {
     TRACE();
 
     //
@@ -150,9 +141,9 @@ ErrorCode EpochZoneHeap::Create(size_t shelf_size, size_t min_alloc_size, mode_t
         return POOL_FOUND;
     } else {
         ErrorCode ret = NO_ERROR;
-      
+
         // Round off the shelf size to next power of 2
-        shelf_size = next_power_of_two (shelf_size);
+        shelf_size = next_power_of_two(shelf_size);
 
         // create an empty pool
         ret = pool_.Create(shelf_size, mode);
@@ -168,7 +159,8 @@ ErrorCode EpochZoneHeap::Create(size_t shelf_size, size_t min_alloc_size, mode_t
         ShelfIndex shelf_idx;
 
         shelf_idx = kHeaderIdx;
-        header_size_ = get_header_size_from_size(shelf_size, min_alloc_size, shelf_idx);
+        header_size_ =
+            get_header_size_from_size(shelf_size, min_alloc_size, shelf_idx);
         ret = pool_.AddShelf(shelf_idx,
                              [this](ShelfFile *shelf, size_t shelf_size) {
                                  ShelfRegion shelf_region(shelf->GetPath());
@@ -200,7 +192,7 @@ ErrorCode EpochZoneHeap::Create(size_t shelf_size, size_t min_alloc_size, mode_t
         }
 
         // map region
-        //size_t header_size = region_->Size();
+        // size_t header_size = region_->Size();
         ret = region_->Map(NULL, header_size_, PROT_READ | PROT_WRITE,
                            MAP_SHARED, 0, (void **)&mapped_addr_[shelf_num]);
         if (ret != NO_ERROR) {
@@ -213,30 +205,30 @@ ErrorCode EpochZoneHeap::Create(size_t shelf_size, size_t min_alloc_size, mode_t
 
         // reserve the 5 global lists for delayed free
         uint64_t reserved =
-            round_up(kListCnt * sizeof(ZoneEntryStack),kCacheLineSize) + 
-                     round_up(sizeof(struct GlobalHeader),kCacheLineSize);
+            round_up(kListCnt * sizeof(ZoneEntryStack), kCacheLineSize) +
+            round_up(sizeof(struct GlobalHeader), kCacheLineSize);
 
         fam_memset_persist(mapped_addr_[shelf_num], 0, reserved);
 
         // use this region to help create the zone
-        header_[shelf_num] = (void *)((char *)mapped_addr_[shelf_num] + reserved);
+        header_[shelf_num] =
+            (void *)((char *)mapped_addr_[shelf_num] + reserved);
 
         shelf_idx = kZoneIdx;
         min_obj_size_ = min_alloc_size;
         header_size_ = header_size_ - reserved;
         ret = pool_.AddShelf(shelf_idx,
-                             [this](ShelfFile *shelf, size_t shelf_size)
-                            {
-                                ShelfHeap shelf_heap(shelf->GetPath());
-                                return shelf_heap.Create(shelf_size, header_[0], header_size_, min_obj_size_);
-                            },
-                            false,
-                            mode
-                            );
-        if (ret != NO_ERROR)
-        {
+                             [this](ShelfFile *shelf, size_t shelf_size) {
+                                 ShelfHeap shelf_heap(shelf->GetPath());
+                                 return shelf_heap.Create(
+                                     shelf_size, header_[0], header_size_,
+                                     min_obj_size_);
+                             },
+                             false, mode);
+        if (ret != NO_ERROR) {
             // unmap and close the region
-            ret = region_->Unmap(mapped_addr_[shelf_num], header_size_ + reserved);
+            ret = region_->Unmap(mapped_addr_[shelf_num],
+                                 header_size_ + reserved);
             if (ret != NO_ERROR) {
                 return HEAP_CREATE_FAILED;
             }
@@ -252,10 +244,10 @@ ErrorCode EpochZoneHeap::Create(size_t shelf_size, size_t min_alloc_size, mode_t
         // TODO: Do we need atomic operation here? May not, As create
         // is already protected by locks.
         //
-        fam_atomic_u64_write (&gh_->sz[0].headersize, header_size_ + reserved);
-        fam_atomic_u64_write (&gh_->sz[0].headeroffset, 0);
-        fam_atomic_u64_write (&gh_->sz[0].shelfsize, shelf_size);
-        fam_atomic_u64_write (&gh_->total_shelfs, 1);
+        fam_atomic_u64_write(&gh_->sz[0].headersize, header_size_ + reserved);
+        fam_atomic_u64_write(&gh_->sz[0].headeroffset, 0);
+        fam_atomic_u64_write(&gh_->sz[0].shelfsize, shelf_size);
+        fam_atomic_u64_write(&gh_->total_shelfs, 1);
 
         // unmap and close the region
         ret = region_->Unmap(mapped_addr_[shelf_num], header_size_ + reserved);
@@ -279,97 +271,99 @@ ErrorCode EpochZoneHeap::Create(size_t shelf_size, size_t min_alloc_size, mode_t
 
 //
 // 1. The input to the resize is new total size
-//    If new size less than existing size, we do not need to do anything 
+//    If new size less than existing size, we do not need to do anything
 //    - return NO_ERROR.
 //
-// 2. Zone has a restriction that every shelf should be a power of 2. 
+// 2. Zone has a restriction that every shelf should be a power of 2.
 //    So convert the size to next power of 2.
 //
 ErrorCode EpochZoneHeap::Resize(size_t size) {
     TRACE();
     // TODO: Currently resize can be performed only on open heap
     if (IsOpen() != true) {
-       LOG(error) <<"Heap is not open";
-       return HEAP_NOT_OPEN;
+        LOG(error) << "Heap is not open";
+        return HEAP_NOT_OPEN;
     }
     LOG(trace) << "Resize Heap, size: " << size;
     ErrorCode ret = NO_ERROR;
-   
+
     // Set the resize in progress bit
     uint64_t old_value = 0;
     uint64_t new_value = OP_RESIZE;
-    old_value = fam_atomic_u64_compare_and_store(&gh_->op_in_progress, 0,
-                                                 new_value);
+    old_value =
+        fam_atomic_u64_compare_and_store(&gh_->op_in_progress, 0, new_value);
     if (old_value != 0) {
         return HEAP_BUSY;
     }
 
     mode_t perm;
-    // Read permission, So that we use latest permission 
+    // Read permission, So that we use latest permission
     ret = region_->GetPermission(&perm);
     if (ret != NO_ERROR) {
-       fam_atomic_u64_write(&gh_->op_in_progress, 0);
-       return HEAP_RESIZE_FAILED;
-    }      
+        fam_atomic_u64_write(&gh_->op_in_progress, 0);
+        return HEAP_RESIZE_FAILED;
+    }
 
     // Get current total data shelfs.
     int shelf_num = get_total_data_shelfs();
-    // We will be able to create kMaxShelfCount - 1 shelfs as one shelf is needed
-    // for header.
-    if(shelf_num >= (Pool::kMaxShelfCount-1)) {
-       fam_atomic_u64_write(&gh_->op_in_progress, 0);
-       return HEAP_RESIZE_FAILED;
+    // We will be able to create kMaxShelfCount - 1 shelfs as one shelf is
+    // needed for header.
+    if (shelf_num >= (Pool::kMaxShelfCount - 1)) {
+        fam_atomic_u64_write(&gh_->op_in_progress, 0);
+        return HEAP_RESIZE_FAILED;
     }
     //
     // We need to get the new header size,
-    // 1. Current total header size, current_header_size 
+    // 1. Current total header size, current_header_size
     // 2. Required header size, new_header_size
     // total_header_size = current_header_size + new_header_size
     //
-    // Get current header size and total shelf size.    
+    // Get current header size and total shelf size.
     size_t current_header_size = get_total_header_size();
     size_t current_total_size = get_total_size();
 
     // If we are already at the required size, Do not resize
-    if(size <= current_total_size) {
-        LOG(trace) << "Already at the specified size, no need to resize, current size: "
-                   <<size<<" Requested size: "<<current_total_size;
+    if (size <= current_total_size) {
+        LOG(trace) << "Already at the specified size, no need to resize, "
+                      "current size: "
+                   << size << " Requested size: " << current_total_size;
         fam_atomic_u64_write(&gh_->op_in_progress, 0);
         return NO_ERROR;
-    }  
+    }
     // Convert the new shelf size to power of 2
     shelf_size_for_create_ = next_power_of_two(size - current_total_size);
-    
-    // Get the required header size for new shelf
-    size_t new_header_size = get_header_size_from_size(shelf_size_for_create_, min_obj_size_, (ShelfIndex)shelf_num);
-    // Add this to total header size
-    size_t total_header_size = new_header_size + current_header_size;                
 
-    
-    // Check if a previous resize has already resized the header more than current required value    
+    // Get the required header size for new shelf
+    size_t new_header_size = get_header_size_from_size(
+        shelf_size_for_create_, min_obj_size_, (ShelfIndex)shelf_num);
+    // Add this to total header size
+    size_t total_header_size = new_header_size + current_header_size;
+
+    // Check if a previous resize has already resized the header more than
+    // current required value
     if (region_->Size() >= total_header_size) {
         LOG(trace) << "Header already resized, skipping resize header";
-    }
-    else {
+    } else {
         // Truncate the header
         ret = region_->Resize(total_header_size);
         if (ret != NO_ERROR) {
-           fam_atomic_u64_write(&gh_->op_in_progress, 0);
-           return ret;
+            fam_atomic_u64_write(&gh_->op_in_progress, 0);
+            return ret;
         }
     }
     // map the header
-    ret = region_->Map(NULL, new_header_size, PROT_READ | PROT_WRITE, MAP_SHARED,
-                 current_header_size, (void **)&mapped_addr_[shelf_num]);
+    ret =
+        region_->Map(NULL, new_header_size, PROT_READ | PROT_WRITE, MAP_SHARED,
+                     current_header_size, (void **)&mapped_addr_[shelf_num]);
     if (ret != NO_ERROR) {
-        std::cout << "Zone: region map failed " << ret << std::endl;
         LOG(error) << "Zone: region map failed " << (uint64_t)pool_id_;
         fam_atomic_u64_write(&gh_->op_in_progress, 0);
         return HEAP_RESIZE_FAILED;
     }
 
     // Set header_ , global_list_
-    uint64_t reserved = round_up(kListCnt * sizeof(ZoneEntryStack), kCacheLineSize);
+    uint64_t reserved =
+        round_up(kListCnt * sizeof(ZoneEntryStack), kCacheLineSize);
     fam_memset_persist(mapped_addr_[shelf_num], 0, reserved);
 
     header_[shelf_num] = (void *)((char *)mapped_addr_[shelf_num] + reserved);
@@ -380,9 +374,10 @@ ErrorCode EpochZoneHeap::Resize(size_t size) {
 
     // Check if previous unfinished resize has a shelf created.
     // If yes remove the shelf
-    if (pool_.CheckShelf(shelf_idx) == true) {    
-        LOG(trace) << "Zone: Removing shelf created by previous unfinished resize " 
-                   << (uint64_t)pool_id_<<" "<<(int)shelf_idx; 
+    if (pool_.CheckShelf(shelf_idx) == true) {
+        LOG(trace)
+            << "Zone: Removing shelf created by previous unfinished resize "
+            << (uint64_t)pool_id_ << " " << (int)shelf_idx;
         ret = pool_.RemoveShelf(shelf_idx);
         if (ret != NO_ERROR) {
             fam_atomic_u64_write(&gh_->op_in_progress, 0);
@@ -391,27 +386,26 @@ ErrorCode EpochZoneHeap::Resize(size_t size) {
         }
     }
     // Create new shelf
-    ret = pool_.AddShelf(
-        shelf_idx, [this](ShelfFile *shelf, size_t shelf_size) {
-                       ShelfHeap shelf_heap(shelf->GetPath());
-                       return shelf_heap.Create(
-                           shelf_size_for_create_, header_[shelf_id_for_create_ - 1],
-                           header_size_, min_obj_size_);
-                   },
-        false,
-        perm);
+    ret = pool_.AddShelf(shelf_idx,
+                         [this](ShelfFile *shelf, size_t shelf_size) {
+                             ShelfHeap shelf_heap(shelf->GetPath());
+                             return shelf_heap.Create(
+                                 shelf_size_for_create_,
+                                 header_[shelf_id_for_create_ - 1],
+                                 header_size_, min_obj_size_);
+                         },
+                         false, perm);
     if (ret != NO_ERROR) {
         fam_atomic_u64_write(&gh_->op_in_progress, 0);
-        region_->Unmap(mapped_addr_[shelf_num], new_header_size); 
+        region_->Unmap(mapped_addr_[shelf_num], new_header_size);
         return ret;
     }
     // Update the gh_ region
-    fam_atomic_u64_write (&gh_->sz[shelf_num].headersize, new_header_size);
-    fam_atomic_u64_write (&gh_->sz[shelf_num].headeroffset, current_header_size);
-    fam_atomic_u64_write (&gh_->sz[shelf_num].shelfsize, shelf_size_for_create_);
-    fam_atomic_64_fetch_add (&(int64_t&)gh_->total_shelfs, 1);
+    fam_atomic_u64_write(&gh_->sz[shelf_num].headersize, new_header_size);
+    fam_atomic_u64_write(&gh_->sz[shelf_num].headeroffset, current_header_size);
+    fam_atomic_u64_write(&gh_->sz[shelf_num].shelfsize, shelf_size_for_create_);
+    fam_atomic_64_fetch_add(&(int64_t &)gh_->total_shelfs, 1);
     fam_atomic_u64_write(&gh_->op_in_progress, 0);
-
 
     // Open the newly added shelfs
     ret = OpenNewShelfs();
@@ -421,7 +415,7 @@ ErrorCode EpochZoneHeap::Resize(size_t size) {
 //
 // SetPermission : PreConditions : Heap needs to be Opened.
 // @param mode : New permission to be set.
-// 
+//
 // Code Flow :
 // 1. Check if Heap Open, If not Open, return Error.
 // 2. Check if any other metadata operation in progress.
@@ -432,24 +426,23 @@ ErrorCode EpochZoneHeap::Resize(size_t size) {
 // 6. Set permission of header shelf.
 // 7. Reset PERMISSION_CHANGE_IN_PROGRESS bit.
 //
-ErrorCode EpochZoneHeap::SetPermission (mode_t mode) {
+ErrorCode EpochZoneHeap::SetPermission(mode_t mode) {
     TRACE();
 
     if (IsOpen() != true) {
-       LOG(error) <<"Heap is not open";
-       return HEAP_NOT_OPEN;
+        LOG(error) << "Heap is not open";
+        return HEAP_NOT_OPEN;
     }
     LOG(trace) << "ChangePermission, mode: " << mode;
     ErrorCode ret = NO_ERROR;
 
-
     // Set the change permission in progress bit
     uint64_t old_value = 0;
     uint64_t new_value = OP_CHANGE_PERM;
-    old_value = fam_atomic_u64_compare_and_store(&gh_->op_in_progress, 0,
-                                                 new_value);
+    old_value =
+        fam_atomic_u64_compare_and_store(&gh_->op_in_progress, 0, new_value);
     if (old_value != 0) {
-       return HEAP_BUSY;
+        return HEAP_BUSY;
     }
 
     // Check current permission and proposed permission, if it is same
@@ -458,65 +451,64 @@ ErrorCode EpochZoneHeap::SetPermission (mode_t mode) {
     ret = region_->GetPermission(&perm);
     if (ret != NO_ERROR) {
         LOG(fatal) << "SetPermission: Reading current permission failed: "
-                 << ret;
+                   << ret;
         fam_atomic_u64_write(&gh_->op_in_progress, 0);
         return HEAP_SET_PERMISSION_FAILED;
     }
     if ((mode & PERM_MASK) == perm) {
         LOG(trace) << "Already set to requested permission, Returning success";
         fam_atomic_u64_write(&gh_->op_in_progress, 0);
-        return NO_ERROR;   
+        return NO_ERROR;
     }
-       
+
     // Set permission of pool metadata shelf
     ret = pool_.SetPermission(mode);
     if (ret != NO_ERROR) {
-      LOG(fatal) << "SetPermission: MetadataShelf set permission failed:"
-                 << ret;
-      fam_atomic_u64_write(&gh_->op_in_progress, 0);
-      return HEAP_SET_PERMISSION_FAILED;
+        LOG(fatal) << "SetPermission: MetadataShelf set permission failed:"
+                   << ret;
+        fam_atomic_u64_write(&gh_->op_in_progress, 0);
+        return HEAP_SET_PERMISSION_FAILED;
     }
 
     // Open the newly added shelfs
-    ret = OpenNewShelfs();   
+    ret = OpenNewShelfs();
     // Set permission of all shelfs in a loop
-    int total_shelfs = get_total_data_shelfs(); 
-    for (int i=0;i<total_shelfs;i++) {
+    int total_shelfs = get_total_data_shelfs();
+    for (int i = 0; i < total_shelfs; i++) {
         ret = rmb_[i]->SetPermission(mode);
-        if (ret !=NO_ERROR) {
-           LOG(fatal) << "SetPermission: set permission failed for shelf"
-                      << i+1<<" with "<<ret;
-           fam_atomic_u64_write(&gh_->op_in_progress, 0);
-           return HEAP_SET_PERMISSION_FAILED;
-        }          
+        if (ret != NO_ERROR) {
+            LOG(fatal) << "SetPermission: set permission failed for shelf"
+                       << i + 1 << " with " << ret;
+            fam_atomic_u64_write(&gh_->op_in_progress, 0);
+            return HEAP_SET_PERMISSION_FAILED;
+        }
     }
 
     //
-    // Finally, Set permission of header. GetPermission reads the permission of header,
-    // and returns it to user. So the permission of file header is always right.
+    // Finally, Set permission of header. GetPermission reads the permission of
+    // header, and returns it to user. So the permission of file header is
+    // always right.
     //
     ret = region_->SetPermission(mode);
     if (ret != NO_ERROR) {
-      LOG(fatal) << "SetPermission: Header change permission failed:"
-                 << ret;
-      fam_atomic_u64_write(&gh_->op_in_progress, 0);
-      return HEAP_SET_PERMISSION_FAILED;
+        LOG(fatal) << "SetPermission: Header change permission failed:" << ret;
+        fam_atomic_u64_write(&gh_->op_in_progress, 0);
+        return HEAP_SET_PERMISSION_FAILED;
     }
     // Reset in progress bit
-    fam_atomic_u64_write(&gh_->op_in_progress, 0); 
+    fam_atomic_u64_write(&gh_->op_in_progress, 0);
     return NO_ERROR;
 }
 
-ErrorCode EpochZoneHeap::GetPermission (mode_t *mode) {
+ErrorCode EpochZoneHeap::GetPermission(mode_t *mode) {
     TRACE();
     if (IsOpen() == false)
-       return HEAP_GET_PERMISSION_FAILED;
+        return HEAP_GET_PERMISSION_FAILED;
     if (region_->GetPermission(mode) != NO_ERROR) {
-       return HEAP_GET_PERMISSION_FAILED;
+        return HEAP_GET_PERMISSION_FAILED;
     }
     return NO_ERROR;
 }
-
 
 ErrorCode EpochZoneHeap::Destroy() {
     TRACE();
@@ -531,6 +523,40 @@ ErrorCode EpochZoneHeap::Destroy() {
         if (ret != NO_ERROR) {
             return HEAP_DESTROY_FAILED;
         }
+        {
+            std::string path;
+            // get the header shelf
+            ret = pool_.GetShelfPath(kHeaderIdx, path);
+            if (ret != NO_ERROR) {
+                (void)pool_.Close(false);
+                return HEAP_DESTROY_FAILED;
+            }
+            // open region
+            region_ = new ShelfRegion(path);
+            assert(region_ != NULL);
+            ret = region_->Open(O_RDWR);
+            if (ret != NO_ERROR) {
+                LOG(error) << "Zone: region open failed " << (uint64_t)pool_id_;
+                (void)pool_.Close(false);
+                return HEAP_DESTROY_FAILED;
+            }
+
+            // Open gh_
+            ret = region_->Map(
+                NULL, round_up(sizeof(struct GlobalHeader), kCacheLineSize),
+                PROT_READ | PROT_WRITE, MAP_SHARED, 0, (void **)&gh_);
+            if (ret != NO_ERROR) {
+                LOG(error) << "Zone: region map failed " << (uint64_t)pool_id_;
+                ret = region_->Close();
+                if (ret != NO_ERROR) {
+                    return HEAP_DESTROY_FAILED;
+                }
+                delete region_;
+                (void)pool_.Close(false);
+                return HEAP_DESTROY_FAILED;
+            }
+            fam_atomic_u64_write(&gh_->destroy_in_progress, 1);
+        }
         ret = pool_.Recover();
         if (ret != NO_ERROR) {
             LOG(fatal) << "Destroy: Found inconsistency in Heap "
@@ -538,9 +564,9 @@ ErrorCode EpochZoneHeap::Destroy() {
         }
         int total_data_shelfs = get_total_data_shelfs();
         if (total_data_shelfs == -1) {
-           LOG(fatal) << "Destroy: Could not find total data shelfs "
-                      << (uint64_t)pool_id_;
-           return HEAP_DESTROY_FAILED;
+            LOG(fatal) << "Destroy: Could not find total data shelfs "
+                       << (uint64_t)pool_id_;
+            return HEAP_DESTROY_FAILED;
         }
 
         std::string path;
@@ -625,13 +651,14 @@ ErrorCode EpochZoneHeap::Open() {
     }
 
     // Open gh_
-    ret = region_->Map(NULL, round_up(sizeof(struct GlobalHeader),kCacheLineSize), PROT_READ | PROT_WRITE, MAP_SHARED, 0,
-                       (void **)&gh_);
+    ret = region_->Map(NULL,
+                       round_up(sizeof(struct GlobalHeader), kCacheLineSize),
+                       PROT_READ | PROT_WRITE, MAP_SHARED, 0, (void **)&gh_);
     if (ret != NO_ERROR) {
         LOG(error) << "Zone: region map failed " << (uint64_t)pool_id_;
         ret = region_->Close();
         if (ret != NO_ERROR) {
-           return HEAP_OPEN_FAILED;
+            return HEAP_OPEN_FAILED;
         }
         delete region_;
         (void)pool_.Close(false);
@@ -645,35 +672,44 @@ ErrorCode EpochZoneHeap::Open() {
     do {
         ret = OpenShelf(shelf_num);
         if (ret != NO_ERROR) {
-           LOG(error) << "ZoneHeap: OpenShelf  " << shelf_num << "failed for : " << (uint64_t)pool_id_;
-           // Close all the OpenShelfs() and return error.
-           // The current shelf will be closed by OpenShelf code, 
-           // Explicitely close other shelfs
-           while(shelf_num > 0)
-           {
-              shelf_num--;              
-              ret = CloseShelf(shelf_num);
-              if (ret != NO_ERROR) {
-                 LOG(trace) << "ZoneHeap: Open Error Handling, CloseShelf  " 
-                            << shelf_num << "failed for : " << (uint64_t)pool_id_;
-                 // Do not return error here, we will attempt to close everything.
-              }
-           } 
+            LOG(error) << "ZoneHeap: OpenShelf  " << shelf_num
+                       << "failed for : " << (uint64_t)pool_id_;
+            // Close all the OpenShelfs() and return error.
+            // The current shelf will be closed by OpenShelf code,
+            // Explicitely close other shelfs
+            while (shelf_num > 0) {
+                shelf_num--;
+                ret = CloseShelf(shelf_num);
+                if (ret != NO_ERROR) {
+                    LOG(trace)
+                        << "ZoneHeap: Open Error Handling, CloseShelf  "
+                        << shelf_num << "failed for : " << (uint64_t)pool_id_;
+                    // Do not return error here, we will attempt to close
+                    // everything.
+                }
+            }
 
-           (void)region_->Unmap(gh_,  round_up(sizeof(struct GlobalHeader),kCacheLineSize));
-           if (ret != NO_ERROR) {
-              LOG(trace) << "ZoneHeap: Open Error Handling, gh_ unmap failed for : " << (uint64_t)pool_id_;
-              // Do not return error here, we will attempt to close everything.
-           }    
-           ret = region_->Close();
-           if (ret != NO_ERROR) {
-              LOG(trace) << "ZoneHeap: Open Error Handling, region close failed for : " << (uint64_t)pool_id_;
-              // Do not return error here, we will attempt to close everything.
-           }
-           delete region_;
-           (void)pool_.Close(false);
-           return HEAP_OPEN_FAILED;                      
-        }          
+            (void)region_->Unmap(
+                gh_, round_up(sizeof(struct GlobalHeader), kCacheLineSize));
+            if (ret != NO_ERROR) {
+                LOG(trace)
+                    << "ZoneHeap: Open Error Handling, gh_ unmap failed for : "
+                    << (uint64_t)pool_id_;
+                // Do not return error here, we will attempt to close
+                // everything.
+            }
+            ret = region_->Close();
+            if (ret != NO_ERROR) {
+                LOG(trace) << "ZoneHeap: Open Error Handling, region close "
+                              "failed for : "
+                           << (uint64_t)pool_id_;
+                // Do not return error here, we will attempt to close
+                // everything.
+            }
+            delete region_;
+            (void)pool_.Close(false);
+            return HEAP_OPEN_FAILED;
+        }
         shelf_num++;
     } while (shelf_num < total_data_shelfs);
 
@@ -685,12 +721,12 @@ ErrorCode EpochZoneHeap::Open() {
     if (rc != 0) {
         // Close all the OpenShelfs() and return error.
         do {
-           shelf_num--;
-           ret = CloseShelf(shelf_num);
-           if (ret != NO_ERROR) {
-              return HEAP_OPEN_FAILED;
-           }
-        } while(shelf_num > 0);
+            shelf_num--;
+            ret = CloseShelf(shelf_num);
+            if (ret != NO_ERROR) {
+                return HEAP_OPEN_FAILED;
+            }
+        } while (shelf_num > 0);
         return HEAP_OPEN_FAILED;
     }
 
@@ -706,22 +742,24 @@ ErrorCode EpochZoneHeap::Close() {
     CHECK_IS_OPEN();
     ErrorCode ret = NO_ERROR;
 
-    // stop the cleaner thread
-    int rc = StopWorker();
-    if (rc != 0) {
-        return HEAP_CLOSE_FAILED;
+    if (!is_invalid_) {
+        // stop the cleaner thread
+        int rc = StopWorker();
+        if (rc != 0) {
+            return HEAP_CLOSE_FAILED;
+        }
     }
-
     // close the rmb
     for (int shelf_num = (int)(total_mapped_shelfs_ - 1); shelf_num >= 0;
          shelf_num--) {
         ret = CloseShelf(shelf_num);
-        if (ret != NO_ERROR) {     
-           return HEAP_CLOSE_FAILED;
+        if (ret != NO_ERROR) {
+            return HEAP_CLOSE_FAILED;
         }
     }
     // Unmap the gh_
-    ret = region_->Unmap(gh_,  round_up(sizeof(struct GlobalHeader),kCacheLineSize));
+    ret = region_->Unmap(gh_,
+                         round_up(sizeof(struct GlobalHeader), kCacheLineSize));
     if (ret != NO_ERROR) {
         return HEAP_CLOSE_FAILED;
     }
@@ -767,21 +805,21 @@ GlobalPtr EpochZoneHeap::Alloc(size_t size) {
     GlobalPtr ptr;
     Offset offset = 0;
     int shelf_num = -1;
-    //int total_shelf = get_total_data_shelfs();
+    // int total_shelf = get_total_data_shelfs();
     int total_shelf = total_mapped_shelfs_;
-    do {        
+    do {
         shelf_num = (shelf_num + 1);
 
-        if(shelf_num == total_mapped_shelfs_) {
+        if (shelf_num == total_mapped_shelfs_) {
             total_shelf = get_total_data_shelfs();
-            if(total_shelf > total_mapped_shelfs_) {               
-               OpenNewShelfs();
-            }
-            else
-               break;
+            if (total_shelf > total_mapped_shelfs_) {
+                OpenNewShelfs();
+            } else
+                break;
         }
         offset = rmb_[shelf_num]->Alloc(size);
-    } while (rmb_[shelf_num]->IsValidOffset(offset) == false && shelf_num < total_mapped_shelfs_);
+    } while (rmb_[shelf_num]->IsValidOffset(offset) == false &&
+             shelf_num < total_mapped_shelfs_);
     if (offset == 0)
         return 0;
     else
@@ -789,8 +827,8 @@ GlobalPtr EpochZoneHeap::Alloc(size_t size) {
                          offset);
 }
 
-
-// The offset returned by AllocOffset has Offset + ((shelf_idx-1) << kOffsetShift)
+// The offset returned by AllocOffset has Offset + ((shelf_idx-1) <<
+// kOffsetShift)
 Offset EpochZoneHeap::AllocOffset(size_t size) {
     GlobalPtr global_ptr = Alloc(size);
 
@@ -800,10 +838,11 @@ Offset EpochZoneHeap::AllocOffset(size_t size) {
     ShelfId shelf_id = global_ptr.GetShelfId();
     ShelfIndex shelf_idx = shelf_id.GetShelfIndex();
     // Left shift shelf_idx by kOffsetShift.
-    // We cant use kOffsetShift directly as it is a private member of global_ptr.
-    // So we create a GlobalPtr with poolId 0 and shelfIndex as shelf_idx
-    // and return uint64_t.
-    return GlobalPtr(ShelfId(0, (ShelfIndex)((int)shelf_idx - 1)),offset).ToUINT64();
+    // We cant use kOffsetShift directly as it is a private member of
+    // global_ptr. So we create a GlobalPtr with poolId 0 and shelfIndex as
+    // shelf_idx and return uint64_t.
+    return GlobalPtr(ShelfId(0, (ShelfIndex)((int)shelf_idx - 1)), offset)
+        .ToUINT64();
 }
 
 void EpochZoneHeap::Free(GlobalPtr global_ptr) {
@@ -813,20 +852,20 @@ void EpochZoneHeap::Free(GlobalPtr global_ptr) {
     ShelfIndex shelf_idx = shelf_id.GetShelfIndex();
 
     // The shelf is not yet open
-    if(shelf_idx > total_mapped_shelfs_) {       
-       ErrorCode ret = OpenNewShelfs();
-       // Free does not return any value, So we will need to throw exception
-       if (ret != NO_ERROR) {         
-          LOG(trace)<<"mapping new shelf failed: "<<ret;
-          return;
-       }
+    if (shelf_idx > total_mapped_shelfs_) {
+        ErrorCode ret = OpenNewShelfs();
+        // Free does not return any value, So we will need to throw exception
+        if (ret != NO_ERROR) {
+            LOG(trace) << "mapping new shelf failed: " << ret;
+            return;
+        }
     }
 
     rmb_[shelf_idx - 1]->Free(offset);
 }
 
 //
-// Offset has the (shelfindex - 1) also in it. 
+// Offset has the (shelfindex - 1) also in it.
 // i.e offset = ((shelfIndex - 1) << 40) + offset
 //
 void EpochZoneHeap::Free(Offset offset) {
@@ -838,13 +877,14 @@ void EpochZoneHeap::Free(Offset offset) {
     // Get only the offset from shelfIndex + offset
     offset = get_offset_from_shelfIndexoffset(offset);
 
-    if(shelf_num >= total_mapped_shelfs_) {       
-       ErrorCode ret = OpenNewShelfs();
-       // TODO: Free does not return any value, So we will need to throw exception
-       if (ret != NO_ERROR) {         
-          LOG(trace)<<"mapping new shelf failed: "<<ret;
-          return;
-       }
+    if (shelf_num >= total_mapped_shelfs_) {
+        ErrorCode ret = OpenNewShelfs();
+        // TODO: Free does not return any value, So we will need to throw
+        // exception
+        if (ret != NO_ERROR) {
+            LOG(trace) << "mapping new shelf failed: " << ret;
+            return;
+        }
     }
     rmb_[shelf_num]->Free(offset);
 }
@@ -862,14 +902,14 @@ void EpochZoneHeap::Free(EpochOp &op, GlobalPtr global_ptr) {
     ShelfId shelf_id = global_ptr.GetShelfId();
     ShelfIndex shelf_idx = shelf_id.GetShelfIndex();
 
-    if(shelf_idx > total_mapped_shelfs_) {
+    if (shelf_idx > total_mapped_shelfs_) {
         ErrorCode ret = OpenNewShelfs();
-        // TODO: Free does not return any value, So we will need to throw exception
+        // TODO: Free does not return any value, So we will need to throw
+        // exception
         if (ret != NO_ERROR) {
-            LOG(trace)<<"mapping new shelf failed: "<<ret;
+            LOG(trace) << "mapping new shelf failed: " << ret;
             return;
         }
-
     }
     if (rmb_[shelf_idx - 1]->IsValidOffset(offset) == false)
         return;
@@ -878,68 +918,72 @@ void EpochZoneHeap::Free(EpochOp &op, GlobalPtr global_ptr) {
         EpochCounter e = op.reported_epoch();
         LOG(trace) << "delay freeing block [" << offset << "] at epoch "
                    << e + 3;
-        global_list_[shelf_idx - 1][(e + 3) % kListCnt]
-            .push(bitmap_start_[shelf_idx - 1], offset / min_obj_size_);
+        global_list_[shelf_idx - 1][(e + 3) % kListCnt].push(
+            bitmap_start_[shelf_idx - 1], offset / min_obj_size_);
     }
 }
 
 ErrorCode EpochZoneHeap::OpenShelf(int shelf_num) {
     std::string path;
-    
-    uint64_t headersize = fam_atomic_u64_read (&gh_->sz[shelf_num].headersize); 
-    uint64_t headeroffset =  fam_atomic_u64_read (&gh_->sz[shelf_num].headeroffset);
-    uint64_t shelfsize = fam_atomic_u64_read (&gh_->sz[shelf_num].shelfsize);
+
+    uint64_t headersize = fam_atomic_u64_read(&gh_->sz[shelf_num].headersize);
+    uint64_t headeroffset =
+        fam_atomic_u64_read(&gh_->sz[shelf_num].headeroffset);
+    uint64_t shelfsize = fam_atomic_u64_read(&gh_->sz[shelf_num].shelfsize);
     // map the header for shelf 'shelf_num'
-    ErrorCode ret = region_->Map(NULL, headersize, PROT_READ | PROT_WRITE, 
-                       MAP_SHARED, headeroffset, 
-                      (void **)&mapped_addr_[shelf_num]);
+    ErrorCode ret =
+        region_->Map(NULL, headersize, PROT_READ | PROT_WRITE, MAP_SHARED,
+                     headeroffset, (void **)&mapped_addr_[shelf_num]);
     if (ret != NO_ERROR) {
-        std::cout << "Zone: region map failed " << ret << std::endl;
         LOG(error) << "Zone: region map failed " << (uint64_t)pool_id_;
         return HEAP_OPEN_FAILED;
     }
     size_t gh_size = 0;
     if (shelf_num == 0)
-       gh_size = round_up(sizeof(struct GlobalHeader),kCacheLineSize);
+        gh_size = round_up(sizeof(struct GlobalHeader), kCacheLineSize);
 
     // get the global freelists
-    global_list_[shelf_num] = (ZoneEntryStack *)((char*)mapped_addr_[shelf_num] + gh_size);    
-    uint64_t reserved = round_up( kListCnt * sizeof(ZoneEntryStack), kCacheLineSize) + gh_size ;
-    
+    global_list_[shelf_num] =
+        (ZoneEntryStack *)((char *)mapped_addr_[shelf_num] + gh_size);
+    uint64_t reserved =
+        round_up(kListCnt * sizeof(ZoneEntryStack), kCacheLineSize) + gh_size;
+
     header_[shelf_num] = (void *)((char *)mapped_addr_[shelf_num] +
-                                          round_up(reserved, kCacheLineSize));
+                                  round_up(reserved, kCacheLineSize));
     // get the zone shelf
     ret = pool_.GetShelfPath((ShelfIndex)(shelf_num + 1), path);
-    if (ret != NO_ERROR) {            
+    if (ret != NO_ERROR) {
         // unmap the region
         ret = region_->Unmap(mapped_addr_[shelf_num], headersize);
         return HEAP_OPEN_FAILED;
-     }
+    }
 
     // open rmb
     rmb_[shelf_num] =
-            new ShelfHeap(path, ShelfId(pool_id_, (ShelfIndex)(shelf_num + 1)));
+        new ShelfHeap(path, ShelfId(pool_id_, (ShelfIndex)(shelf_num + 1)));
     assert(rmb_[shelf_num] != NULL);
     ret = rmb_[shelf_num]->Open(header_[shelf_num], headersize - reserved);
     if (ret != NO_ERROR) {
-         // unmap the region
-         ret = region_->Unmap(mapped_addr_[shelf_num], headersize);
-         LOG(error) << "Zone: rmb open failed " << (uint64_t)pool_id_;
-         return HEAP_OPEN_FAILED;
+        // unmap the region
+        ret = region_->Unmap(mapped_addr_[shelf_num], headersize);
+        LOG(error) << "Zone: rmb open failed " << (uint64_t)pool_id_;
+        return HEAP_OPEN_FAILED;
     }
-    bitmap_start_[shelf_num] = (void*)((char*)header_[shelf_num] + rmb_[shelf_num]->get_bitmap_offset());
+    bitmap_start_[shelf_num] = (void *)((char *)header_[shelf_num] +
+                                        rmb_[shelf_num]->get_bitmap_offset());
 
     // Validation to check if shelf size and shelf size in gh_ is same
-    if (rmb_[shelf_num]->Size() != shelfsize) {    
-        LOG(error) << "Zone: Shelf size in header and actual shelf different, shelf id: " 
-                   << shelf_num+1;
+    if (rmb_[shelf_num]->Size() != shelfsize) {
+        LOG(error) << "Zone: Shelf size in header and actual shelf different, "
+                      "shelf id: "
+                   << shelf_num + 1;
         (void)region_->Unmap(mapped_addr_[shelf_num], headersize);
-        (void)rmb_[shelf_num]->Close();   
-        return HEAP_OPEN_FAILED;        
-    } 
+        (void)rmb_[shelf_num]->Close();
+        return HEAP_OPEN_FAILED;
+    }
     rmb_size_[shelf_num] = rmb_[shelf_num]->Size();
     total_mapped_shelfs_ = shelf_num + 1;
-    return NO_ERROR;    
+    return NO_ERROR;
 }
 
 // The caller of this function has to ensure shelf_num is a valid shelf
@@ -966,21 +1010,23 @@ ErrorCode EpochZoneHeap::CloseShelf(int shelf_num) {
     return NO_ERROR;
 }
 
-// This function is invoked by processes which want to open the shelf resized from other processes.
+// This function is invoked by processes which want to open the shelf resized
+// from other processes.
 ErrorCode EpochZoneHeap::OpenNewShelfs() {
     int new_total_shelfs = get_total_data_shelfs();
     ErrorCode ret;
 
-    // Verify if we have already mapped all the shelfs    
-    if(new_total_shelfs == total_mapped_shelfs_)
-       return NO_ERROR;
+    // Verify if we have already mapped all the shelfs
+    if (new_total_shelfs == total_mapped_shelfs_)
+        return NO_ERROR;
 
     for (int shelf_num = total_mapped_shelfs_; shelf_num < new_total_shelfs;
          shelf_num++) {
-         
+
         ret = OpenShelf(shelf_num);
         if (ret != NO_ERROR) {
-            LOG(error) << "ZoneHeap: OpenShelf  " << shelf_num << "failed for : " << (uint64_t)pool_id_;
+            LOG(error) << "ZoneHeap: OpenShelf  " << shelf_num
+                       << "failed for : " << (uint64_t)pool_id_;
             return HEAP_OPEN_FAILED;
         }
     }
@@ -1035,26 +1081,25 @@ int EpochZoneHeap::get_shelfnum_from_shelfIndexoffset(Offset offset) {
 }
 
 int EpochZoneHeap::get_total_data_shelfs() {
-    // gh_ will be NULL during destroy heap, in that case read the 
+    // gh_ will be NULL during destroy heap, in that case read the
     // total shelfs from pool.
     if (gh_ != NULL) {
-        // Do we need to use atomic operation here ? 
+        // Do we need to use atomic operation here ?
         // May not since only resize can change the value
-        return (int)fam_atomic_u64_read (&gh_->total_shelfs);
-    }
-    else {
-        // During destroy the heap is not open. 
+        return (int)fam_atomic_u64_read(&gh_->total_shelfs);
+    } else {
+        // During destroy the heap is not open.
         // We need to get total shelf from pool
         ShelfIndex shelf_idx = pool_.Size();
         ErrorCode ret;
         // Find the next free shelf, if it returns
         // free shelf not found, return kMaxShelfCount.
-        ret = pool_.FindNextFreeShelf(shelf_idx);    
+        ret = pool_.FindNextFreeShelf(shelf_idx);
         if (ret != NO_ERROR) {
             if (ret == POOL_SHELF_NOT_FOUND)
-                shelf_idx = Pool::kMaxShelfCount;       
-            else 
-               return -1; // This is not expected, return -1. 
+                shelf_idx = Pool::kMaxShelfCount;
+            else
+                return -1; // This is not expected, return -1.
         }
         return (int)shelf_idx - 1;
     }
@@ -1068,14 +1113,16 @@ size_t EpochZoneHeap::get_header_shelf_size(int shelf_num) {
 // header size of a shelf should be read from shelf_heap.
 // In addition to it we have epoch free list and global header.
 //
-size_t EpochZoneHeap::get_header_size_from_size(size_t size, size_t min_alloc_size, ShelfIndex shelf_idx) {
+size_t EpochZoneHeap::get_header_size_from_size(size_t size,
+                                                size_t min_alloc_size,
+                                                ShelfIndex shelf_idx) {
     size_t gh_size = 0;
     size_t total_size = 0;
     if (shelf_idx == 0)
-       gh_size = round_up(sizeof(struct GlobalHeader),kCacheLineSize);
-    total_size = ShelfHeap::get_header_size(size, min_alloc_size) + 
-           round_up(kListCnt * sizeof(ZoneEntryStack) , kCacheLineSize) +
-           gh_size;
+        gh_size = round_up(sizeof(struct GlobalHeader), kCacheLineSize);
+    total_size = ShelfHeap::get_header_size(size, min_alloc_size) +
+                 round_up(kListCnt * sizeof(ZoneEntryStack), kCacheLineSize) +
+                 gh_size;
     total_size = round_up(total_size, header_size_round_up());
     return total_size;
 }
@@ -1084,7 +1131,8 @@ size_t EpochZoneHeap::get_total_header_size() {
     int total_shelfs = get_total_data_shelfs();
     size_t total_header_size = 0;
     for (int shelf_num = 0; shelf_num < total_shelfs; shelf_num++) {
-        total_header_size += fam_atomic_u64_read(&gh_->sz[shelf_num].headersize);
+        total_header_size +=
+            fam_atomic_u64_read(&gh_->sz[shelf_num].headersize);
     }
     return total_header_size;
 }
@@ -1172,23 +1220,42 @@ void EpochZoneHeap::BackgroundWorker() {
             }
         }
         // do work
-        for (int shelf_num = 0; shelf_num < total_mapped_shelfs_;
-             shelf_num++) {
+        for (int shelf_num = 0; shelf_num < total_mapped_shelfs_; shelf_num++) {
+
             EpochManager *em = EpochManager::GetInstance();
             EpochOp op(em);
             EpochCounter e = op.reported_epoch();
-
+            if (fam_atomic_u64_read(&gh_->destroy_in_progress)) {
+                is_invalid_ = true;
+                for (int shelf_num = 0; shelf_num < total_mapped_shelfs_;
+                     shelf_num++) {
+                    rmb_[shelf_num]->MarkInvalid();
+                }
+                Close();
+                LOG(trace) << "cleaner: exiting...";
+                return;
+            }
             LOG(trace) << "cleaner: now looking at epoch " << e;
             uint64_t i = 0;
             for (; i < kFreeCnt; i++) {
-                Offset offset = global_list_[shelf_num][e % kListCnt]
-                                    .pop(bitmap_start_[shelf_num]) *
+                Offset offset = global_list_[shelf_num][e % kListCnt].pop(
+                                    bitmap_start_[shelf_num]) *
                                 min_obj_size_;
                 if (offset == 0)
-                    break;                 
+                    break;
                 // TODO: a crash here will leak memory
                 LOG(trace) << " freeing block [" << offset << "]";
                 rmb_[shelf_num]->Free(offset);
+            }
+            if (fam_atomic_u64_read(&gh_->destroy_in_progress)) {
+                is_invalid_ = true;
+                for (int shelf_num = 0; shelf_num < total_mapped_shelfs_;
+                     shelf_num++) {
+                    rmb_[shelf_num]->MarkInvalid();
+                }
+                Close();
+                LOG(trace) << "cleaner: exiting...";
+                return;
             }
             LOG(trace) << " in total " << i << " blocks have been freed";
         }
@@ -1200,9 +1267,9 @@ size_t EpochZoneHeap::MinAllocSize() { return rmb_[0]->MinAllocSize(); }
 
 void EpochZoneHeap::Merge() {
     ASSERT_IS_OPEN();
-    OpenNewShelfs();        
+    OpenNewShelfs();
     // TODO: Handle errors from merge
-    for (int shelf_num = 0;  shelf_num < total_mapped_shelfs_; shelf_num++) 
+    for (int shelf_num = 0; shelf_num < total_mapped_shelfs_; shelf_num++)
         rmb_[shelf_num]->Merge();
 }
 
@@ -1211,7 +1278,7 @@ void EpochZoneHeap::OfflineRecover() {
     OpenNewShelfs();
     fam_atomic_u64_write(&gh_->op_in_progress, 0);
     // TODO: Handle errors from OfflineRecover
-    for (int shelf_num = 0;  shelf_num < total_mapped_shelfs_; shelf_num++)
+    for (int shelf_num = 0; shelf_num < total_mapped_shelfs_; shelf_num++)
         rmb_[shelf_num]->OfflineRecover();
 }
 
@@ -1219,7 +1286,7 @@ void EpochZoneHeap::OnlineRecover() {
     ASSERT_IS_OPEN();
     OpenNewShelfs();
     // TODO: Handle errors from OnlineRecover
-    for (int shelf_num = 0;  shelf_num < (int)total_mapped_shelfs_; shelf_num++)
+    for (int shelf_num = 0; shelf_num < (int)total_mapped_shelfs_; shelf_num++)
         rmb_[shelf_num]->OnlineRecover();
 }
 
@@ -1227,7 +1294,7 @@ void EpochZoneHeap::Stats() {
     ASSERT_IS_OPEN();
     OpenNewShelfs();
     // TODO: Handle errors from Stats
-    for (int shelf_num = 0;  shelf_num < (int)total_mapped_shelfs_; shelf_num++)
+    for (int shelf_num = 0; shelf_num < (int)total_mapped_shelfs_; shelf_num++)
         rmb_[shelf_num]->Stats();
 }
 

--- a/src/allocator/epoch_zone_heap.h
+++ b/src/allocator/epoch_zone_heap.h
@@ -25,81 +25,76 @@
 #ifndef _NVMM_EPOCH_ZONE_HEAP_H_
 #define _NVMM_EPOCH_ZONE_HEAP_H_
 
+#include <condition_variable>
+#include <mutex>
 #include <stddef.h>
 #include <stdint.h>
 #include <thread>
-#include <mutex>
-#include <condition_variable>
 
 #include "nvmm/error_code.h"
 #include "nvmm/global_ptr.h"
-#include "nvmm/shelf_id.h"
 #include "nvmm/heap.h"
+#include "nvmm/shelf_id.h"
 
 #include "shelf_mgmt/pool.h"
 #include "shelf_usage/zone_entry_stack.h"
 
-namespace nvmm{
+namespace nvmm {
 
 class ShelfHeap;
 class ShelfRegion;
 
-
-struct shelf_size 
-{
-   uint64_t headersize;
-   uint64_t headeroffset;
-   uint64_t shelfsize;
-};            
-
-enum EpochZoneHeapOps {
-    OP_RESIZE = 1,
-    OP_CHANGE_PERM = 2
+struct shelf_size {
+    uint64_t headersize;
+    uint64_t headeroffset;
+    uint64_t shelfsize;
 };
+
+enum EpochZoneHeapOps { OP_RESIZE = 1, OP_CHANGE_PERM = 2 };
 
 //
 // This header is in shelf zero, used to store global shelf data strcuture.
 //
 struct GlobalHeader {
     uint64_t op_in_progress;
+    uint64_t destroy_in_progress;
     uint64_t total_shelfs;
     uint64_t total_size;
     shelf_size sz[ShelfId::kMaxShelfCount];
 };
 
-
 // zone heap with delayed free
-// the only difference from the regular zone heap is: we store the 5 global lists for delayed free
-// at the beginning of the header shelf
-class EpochZoneHeap : public Heap
-{
-public:
+// the only difference from the regular zone heap is: we store the 5 global
+// lists for delayed free at the beginning of the header shelf
+class EpochZoneHeap : public Heap {
+  public:
     EpochZoneHeap() = delete;
     EpochZoneHeap(PoolId pool_id);
     ~EpochZoneHeap();
 
-    ErrorCode Create(size_t shelf_size, size_t min_alloc_size, mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
+    ErrorCode Create(size_t shelf_size, size_t min_alloc_size,
+                     mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
     ErrorCode Destroy();
     bool Exist();
     ErrorCode Resize(size_t);
-    ErrorCode SetPermission (mode_t mode);
-    ErrorCode GetPermission (mode_t *mode);
+    ErrorCode SetPermission(mode_t mode);
+    ErrorCode GetPermission(mode_t *mode);
 
     ErrorCode Open();
     ErrorCode Close();
     size_t Size();
-    bool IsOpen()
-    {
-        return is_open_;
-    }
+    bool IsOpen() { return is_open_; }
 
-    GlobalPtr Alloc (size_t size);
-    void Free (GlobalPtr global_ptr);
-    ErrorCode Map(Offset offset, size_t size, void *addr_hint, int prot, void **mapped_addr);
+    bool IsInvalid() { return is_invalid_; }
+
+    GlobalPtr Alloc(size_t size);
+    void Free(GlobalPtr global_ptr);
+    ErrorCode Map(Offset offset, size_t size, void *addr_hint, int prot,
+                  void **mapped_addr);
     ErrorCode Unmap(Offset offset, void *mapped_addr, size_t size);
 
-    GlobalPtr Alloc (EpochOp &op, size_t size);
-    Offset AllocOffset (size_t size);
+    GlobalPtr Alloc(EpochOp &op, size_t size);
+    Offset AllocOffset(size_t size);
 
     void Free(EpochOp &op, GlobalPtr global_ptr);
     void Free(Offset offset);
@@ -115,25 +110,26 @@ public:
     void OfflineRecover();
     void Stats();
 
-private:
+  private:
     static int const kHeaderIdx = 0; // headers for zone
-    static int const kZoneIdx = 1; // zone
+    static int const kZoneIdx = 1;   // zone
 
     static int const kListCnt = 5; // 5 global freelists for delayed free
     static uint64_t const kWorkerSleepMicroSeconds = 50000;
-    uint64_t kFreeCnt = 1000; // free up to 1000 chunks everytime the background worker wakes up
+    uint64_t kFreeCnt =
+        1000; // free up to 1000 chunks everytime the background worker wakes up
     int total_mapped_shelfs_;
 
     GlobalHeader *gh_;
-    
+
     PoolId pool_id_;
     Pool pool_;
 
     size_t rmb_size_[ShelfId::kMaxShelfCount];
     ShelfHeap *rmb_[ShelfId::kMaxShelfCount]; // zone heap
 
-    ShelfRegion *region_; // headers of global freelists + headers of allocated memory chunks fron
-                          // zone heap
+    ShelfRegion *region_; // headers of global freelists + headers of allocated
+                          // memory chunks fron zone heap
     void *mapped_addr_[ShelfId::kMaxShelfCount];
     void *header_[ShelfId::kMaxShelfCount];
     void *bitmap_start_[ShelfId::kMaxShelfCount];
@@ -142,6 +138,7 @@ private:
     uint64_t min_obj_size_;
 
     bool is_open_;
+    bool is_invalid_;
     int shelf_id_for_create_;
     size_t shelf_size_for_create_;
     size_t header_size_;
@@ -149,11 +146,12 @@ private:
     ErrorCode OpenNewShelfs();
     ErrorCode OpenShelf(int shelf_num);
     ErrorCode CloseShelf(int shelf_num);
-    size_t get_header_size_from_size (size_t shelf_size, size_t min_alloc_size, ShelfIndex shelf_idx);
-    size_t get_header_shelf_size (int shelf_num);
-    size_t get_total_header_size ();
-    size_t get_total_size ();
-    int get_total_data_shelfs ();
+    size_t get_header_size_from_size(size_t shelf_size, size_t min_alloc_size,
+                                     ShelfIndex shelf_idx);
+    size_t get_header_shelf_size(int shelf_num);
+    size_t get_total_header_size();
+    size_t get_total_size();
+    int get_total_data_shelfs();
     Offset get_offset_from_shelfIndexoffset(Offset offset);
     int get_shelfnum_from_shelfIndexoffset(Offset offset);
 

--- a/src/shelf_mgmt/shelf_file.cc
+++ b/src/shelf_mgmt/shelf_file.cc
@@ -22,360 +22,287 @@
  *
  */
 
-#include <unistd.h>
 #include <string>
+#include <unistd.h>
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <sys/mman.h>
-#include <errno.h>
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/operations.hpp>
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 
 #include "nvmm/error_code.h"
 #include "nvmm/shelf_id.h"
 
+#include "common/common.h"
 #include "nvmm/fam.h"
 #include "nvmm/log.h"
-#include "common/common.h"
 
 #include "shelf_mgmt/shelf_manager.h"
 
 #include "shelf_mgmt/shelf_file.h"
 
 namespace nvmm {
-    
+
+int64_t ShelfManager::num_heap_instance = 0;
+
 ShelfFile::ShelfFile(std::string pathname)
-    : fd_{-1}, path_{pathname}, shelf_id_{}
-{
-}
+    : fd_{-1}, path_{pathname}, shelf_id_{} {}
 
 ShelfFile::ShelfFile(std::string pathname, ShelfId shelf_id)
-    : fd_{-1}, path_{pathname}, shelf_id_{shelf_id}
-{
-}
-    
+    : fd_{-1}, path_{pathname}, shelf_id_{shelf_id} {}
 
-ShelfFile::~ShelfFile()
-{
-    if (IsOpen() == true)
-    {
+ShelfFile::~ShelfFile() {
+    if (IsOpen() == true) {
         (void)Close();
     }
 }
 
-ErrorCode ShelfFile::Create(mode_t mode, size_t size)
-{
+ErrorCode ShelfFile::Create(mode_t mode, size_t size) {
     TRACE();
-    if (Exist() == true)
-    {
+    if (Exist() == true) {
         return SHELF_FILE_FOUND;
     }
-    if (IsOpen() == true)
-    {
+    if (IsOpen() == true) {
         return SHELF_FILE_OPENED;
     }
-    
+
     ErrorCode ret = NO_ERROR;
     mode_t oldmask = umask(0);
     fd_ = creat(path_.c_str(), mode);
     umask(oldmask);
-    if ( fd_ != -1)
-    {
-        if (size > 0)
-        {
+    if (fd_ != -1) {
+        if (size > 0) {
             ret = Truncate(size);
         }
         (void)Close();
         return ret;
-    }
-    else
-    {
-        if (errno == EEXIST)
-        {
+    } else {
+        if (errno == EEXIST) {
             return SHELF_FILE_FOUND;
-        }
-        else
-        {
+        } else {
             return SHELF_FILE_CREATE_FAILED;
         }
     }
 }
 
-ErrorCode ShelfFile::Destroy()
-{
+ErrorCode ShelfFile::Destroy() {
     TRACE();
     ErrorCode ret = NO_ERROR;
-    if (Exist() == false)
-    {
+    if (Exist() == false) {
         ret = SHELF_FILE_NOT_FOUND;
     }
 
-    if (IsOpen() == true)
-    {
+    if (IsOpen() == true) {
         return SHELF_FILE_OPENED;
     }
-    
+
     boost::filesystem::path shelf_path = boost::filesystem::path(path_.c_str());
 
-    // remove() returns false if the path did not exist in the first place, otherwise true.
-    // NOTE: boost::filesystem::remove() is racy at least up to 1.57.0, see
-    // https://svn.boost.org/trac/boost/ticket/11166
-    // therefore, we try to catch the exception and prevent it from being exposed
-    try
-    {
+    // remove() returns false if the path did not exist in the first place,
+    // otherwise true. NOTE: boost::filesystem::remove() is racy at least up
+    // to 1.57.0, see https://svn.boost.org/trac/boost/ticket/11166 therefore,
+    // we try to catch the exception and prevent it from being exposed
+    try {
         (void)boost::filesystem::remove(shelf_path);
+    } catch (boost::filesystem::filesystem_error const &err) {
+        if (err.code().value() == 2) {
+            LOG(trace) << "boost::filesystem::remove - BUGGY exceptions "
+                       << err.code();
+        } else {
+            LOG(fatal) << "boost::filesystem::remove - REAL exceptions"
+                       << err.code();
+            throw(err);
+        }
     }
-    catch (boost::filesystem::filesystem_error const &err)
-    {
-        if(err.code().value() == 2)
-        {
-            LOG(trace) << "boost::filesystem::remove - BUGGY exceptions " << err.code();
-        }
-        else
-        {
-            LOG(fatal) << "boost::filesystem::remove - REAL exceptions" << err.code();
-            throw (err);
-        }
-    }    
     return ret;
 }
 
-ErrorCode ShelfFile::Truncate(off_t length)
-{
+ErrorCode ShelfFile::Truncate(off_t length) {
     TRACE();
     int ret;
-    if(IsOpen() == false)
-    {
+    if (IsOpen() == false) {
         ret = truncate(path_.c_str(), length);
-    }
-    else
-    {
+    } else {
         ret = ftruncate(fd_, length);
     }
-    if (ret != -1)
-    {
+    if (ret != -1) {
         return NO_ERROR;
-    }
-    else
-    {
-        if (errno == ENOENT)
-        {
+    } else {
+        if (errno == ENOENT) {
             return SHELF_FILE_NOT_FOUND;
-        }
-        else
-        {
+        } else {
             return SHELF_FILE_TRUNCATE_FAILED;
         }
-    }    
+    }
 }
-    
-ErrorCode ShelfFile::Rename(char const *new_pathname)
-{
+
+ErrorCode ShelfFile::Rename(char const *new_pathname) {
     TRACE();
     int ret = rename(path_.c_str(), new_pathname);
-    if (ret != -1)
-    {
+    if (ret != -1) {
         path_ = std::string(new_pathname);
         return NO_ERROR;
-    }
-    else
-    {
+    } else {
         return SHELF_FILE_RENAME_FAILED;
     }
 }
-    
-bool ShelfFile::Exist()
-{
+
+bool ShelfFile::Exist() {
     boost::filesystem::path shelf_path = boost::filesystem::path(path_.c_str());
     return boost::filesystem::exists(shelf_path);
 }
 
-size_t ShelfFile::Size()
-{
-    if(IsOpen() == false)
-    {
-        boost::filesystem::path shelf_path = boost::filesystem::path(path_.c_str());
+size_t ShelfFile::Size() {
+    if (IsOpen() == false) {
+        boost::filesystem::path shelf_path =
+            boost::filesystem::path(path_.c_str());
         return (size_t)boost::filesystem::file_size(shelf_path);
-    }
-    else
-    {
+    } else {
         struct stat buf;
         int ret = fstat(fd_, &buf);
-        if (ret != -1)
-        {
+        if (ret != -1) {
             return (size_t)buf.st_size;
-        }
-        else
-        {
+        } else {
             return (size_t)-1;
         }
-    }    
+    }
 }
 
-ErrorCode ShelfFile::Open(int flags)
-{
+ErrorCode ShelfFile::Open(int flags) {
     TRACE();
-    //TRACE() << path_;    
-    if(IsOpen() == true)
-    {
+    // TRACE() << path_;
+    if (IsOpen() == true) {
         return SHELF_FILE_OPENED;
     }
-    if (Exist() == false)
-    {
+    if (Exist() == false) {
         return SHELF_FILE_NOT_FOUND;
     }
     fd_ = open(path_.c_str(), flags);
-    if (fd_ != -1)
-    {
+    if (fd_ != -1) {
         return NO_ERROR;
-    }
-    else
-    {
-        if (errno == ENOENT)
-        {
+    } else {
+        if (errno == ENOENT) {
             return SHELF_FILE_NOT_FOUND;
-        }
-        else
-        {
+        } else {
             return SHELF_FILE_OPEN_FAILED;
         }
     }
 }
 
-ErrorCode ShelfFile::Close()
-{
+ErrorCode ShelfFile::Close() {
     TRACE();
-    //TRACE() << path_;    
-    if(IsOpen() == false)
-    {
+    // TRACE() << path_;
+    if (IsOpen() == false) {
         return SHELF_FILE_CLOSED;
     }
     int ret = close(fd_);
-    if (ret != -1)
-    {
+    if (ret != -1) {
         fd_ = -1;
         return NO_ERROR;
-    }
-    else
-    {
+    } else {
         return SHELF_FILE_CLOSE_FAILED;
     }
 }
 
-ErrorCode ShelfFile::Map(void *addr_hint, size_t length, int prot, int flags, loff_t offset, void **mapped_addr, bool register_fam_atomic)
-{
+ErrorCode ShelfFile::Map(void *addr_hint, size_t length, int prot, int flags,
+                         loff_t offset, void **mapped_addr,
+                         bool register_fam_atomic) {
     TRACE();
-    if(IsOpen() == false)
-    {
+    if (IsOpen() == false) {
         return SHELF_FILE_CLOSED;
     }
 
     void *ret = mmap(addr_hint, length, prot, flags, fd_, offset);
-    if (ret != MAP_FAILED)
-    {
+    if (ret != MAP_FAILED) {
         *mapped_addr = ret;
-        if (register_fam_atomic == true)
-        {
-            //LOG(fatal) << "register fam atomic " << path_ << " " << (uint64_t)*mapped_addr;
+        if (register_fam_atomic == true) {
+            // LOG(fatal) << "register fam atomic " << path_ << " " <<
+            // (uint64_t)*mapped_addr;
             int rc = fam_atomic_register_region(*mapped_addr, length, fd_, 0);
-            if (rc < 0)
-            {
+            if (rc < 0) {
                 LOG(fatal) << "fam_atomic_register_region failed";
                 return SHELF_FILE_FAM_ATOMIC_REGISTER_REGION_FAILED;
             }
-            //LOG(fatal) << "AFTER register fam atomic " << path_ << " " << (uint64_t)*mapped_addr;
+            // LOG(fatal) << "AFTER register fam atomic " << path_ << " " <<
+            // (uint64_t)*mapped_addr;
         }
-        return NO_ERROR;        
-    }
-    else
-    {
-        return SHELF_FILE_MAP_FAILED;        
+        return NO_ERROR;
+    } else {
+        return SHELF_FILE_MAP_FAILED;
     }
 }
 
-ErrorCode ShelfFile::Unmap(void *mapped_addr, size_t length, bool unregister_fam_atomic)
-{
+ErrorCode ShelfFile::Unmap(void *mapped_addr, size_t length,
+                           bool unregister_fam_atomic) {
     TRACE();
     // TODO: slow!
-    //pmem_persist(mapped_addr, length);
-    if (unregister_fam_atomic == true)
-    {
-        //LOG(fatal) << "unregister fam atomic " << (uint64_t)mapped_addr;
+    // pmem_persist(mapped_addr, length);
+    if (unregister_fam_atomic == true) {
+        // LOG(fatal) << "unregister fam atomic " << (uint64_t)mapped_addr;
         fam_atomic_unregister_region(mapped_addr, length);
-        //LOG(fatal) << "AFTER unregister fam atomic "  << length << " " << (uint64_t)mapped_addr;
+        // LOG(fatal) << "AFTER unregister fam atomic "  << length << " " <<
+        // (uint64_t)mapped_addr;
     }
     int ret = munmap(mapped_addr, length);
-    if (ret != -1)
-    {
+    if (ret != -1) {
         return NO_ERROR;
-    }
-    else
-    {
+    } else {
         return SHELF_FILE_UNMAP_FAILED;
     }
 }
 
-    
-ErrorCode ShelfFile::Map(void *addr_hint, void **mapped_addr)
-{
+ErrorCode ShelfFile::Map(void *addr_hint, void **mapped_addr) {
     TRACE();
-    if(IsOpen() == false)
-    {
+    if (IsOpen() == false) {
         return SHELF_FILE_CLOSED;
     }
 
-    assert(shelf_id_.IsValid() == true);    
+    assert(shelf_id_.IsValid() == true);
     void *addr;
     ShelfManager::Lock();
     addr = ShelfManager::LookupShelf(shelf_id_);
-    if (addr != NULL)
-    {
+    if (addr != NULL) {
         *mapped_addr = addr;
         ShelfManager::Unlock();
         return NO_ERROR;
     }
 
     size_t length = Size();
-    int prot = PROT_READ|PROT_WRITE;
+    int prot = PROT_READ | PROT_WRITE;
     int flags = MAP_SHARED;
     loff_t offset = 0;
 
     ErrorCode ret = Map(addr_hint, length, prot, flags, offset, &addr, true);
-    if (ret == NO_ERROR)
-    {
-        void *actual_addr = ShelfManager::RegisterShelf(shelf_id_, addr, length);
+    if (ret == NO_ERROR) {
+        void *actual_addr =
+            ShelfManager::RegisterShelf(shelf_id_, addr, length);
         assert(actual_addr == addr);
         ShelfManager::Unlock();
         *mapped_addr = actual_addr;
         return NO_ERROR;
-    }
-    else
-    {
+    } else {
         ShelfManager::Unlock();
-        return SHELF_FILE_MAP_FAILED;        
+        return SHELF_FILE_MAP_FAILED;
     }
 }
-    
-ErrorCode ShelfFile::Unmap(void *mapped_addr, bool unregister)
-{
+
+ErrorCode ShelfFile::Unmap(void *mapped_addr, bool unregister) {
     TRACE();
     assert(shelf_id_.IsValid() == true);
-    if (unregister == true)
-    {
+    if (unregister == true) {
         void *addr;
         ShelfManager::Lock();
         addr = ShelfManager::LookupShelf(shelf_id_);
         assert(addr == mapped_addr);
         addr = ShelfManager::UnregisterShelf(shelf_id_);
-        assert(addr == mapped_addr);        
+        assert(addr == mapped_addr);
         ShelfManager::Unlock();
         size_t size = Size();
         return Unmap(mapped_addr, size, true);
-    }
-    else
-    {
+    } else {
         void *addr;
         ShelfManager::Lock();
         addr = ShelfManager::LookupShelf(shelf_id_);
@@ -385,25 +312,33 @@ ErrorCode ShelfFile::Unmap(void *mapped_addr, bool unregister)
     }
 }
 
-ErrorCode ShelfFile::GetPermission(mode_t *mode)
-{
-   TRACE();
-   struct stat st;
-
-   if (stat(path_.c_str(), &st) != 0)
-      return SHELF_FILE_GET_PERM_FAILED;
-
-   *mode = st.st_mode & PERM_MASK;
-   return NO_ERROR;   
+ErrorCode ShelfFile::MarkInvalid() {
+    TRACE();
+    return ShelfManager::MarkInvalid(shelf_id_);
 }
 
-ErrorCode ShelfFile::SetPermission(mode_t mode)
-{
-   TRACE();   
-   if (chmod(path_.c_str(), mode & PERM_MASK) == 0)
-     return NO_ERROR;
-   else
-     return SHELF_FILE_SET_PERM_FAILED;
+bool ShelfFile::IsInvalid() {
+    TRACE();
+    return ShelfManager::IsInvalid(shelf_id_);
 }
-    
+
+ErrorCode ShelfFile::GetPermission(mode_t *mode) {
+    TRACE();
+    struct stat st;
+
+    if (stat(path_.c_str(), &st) != 0)
+        return SHELF_FILE_GET_PERM_FAILED;
+
+    *mode = st.st_mode & PERM_MASK;
+    return NO_ERROR;
+}
+
+ErrorCode ShelfFile::SetPermission(mode_t mode) {
+    TRACE();
+    if (chmod(path_.c_str(), mode & PERM_MASK) == 0)
+        return NO_ERROR;
+    else
+        return SHELF_FILE_SET_PERM_FAILED;
+}
+
 } // namespace nvmm

--- a/src/shelf_mgmt/shelf_file.h
+++ b/src/shelf_mgmt/shelf_file.h
@@ -25,8 +25,8 @@
 #ifndef _NVMM_SHELF_FILE_H_
 #define _NVMM_SHELF_FILE_H_
 
-#include <unistd.h>
 #include <string>
+#include <unistd.h>
 
 #include "nvmm/error_code.h"
 #include "nvmm/shelf_id.h"
@@ -34,48 +34,42 @@
 namespace nvmm {
 
 // a generic abstraction of shelf files on tmpfs
-class ShelfFile
-{
-public:
-    ShelfFile() = delete; // no default    
+class ShelfFile {
+  public:
+    ShelfFile() = delete; // no default
     ShelfFile(std::string pathname);
 
     // shelf_id is needed to register/unregister a shelf with the ShelfManager
-    // TODO: have two kinds of ShelfFile? public (registered) and private (unregistered)?
-    ShelfFile(std::string pathname, ShelfId shelf_id); 
-    ~ShelfFile();        
+    // TODO: have two kinds of ShelfFile? public (registered) and private
+    // (unregistered)?
+    ShelfFile(std::string pathname, ShelfId shelf_id);
+    ~ShelfFile();
 
-    bool IsOpen()
-    {
-        return fd_ != -1;
-    }
-    
-    std::string GetPath()
-    {
-        return path_;
-    }
+    bool IsOpen() { return fd_ != -1; }
 
-    ShelfId GetShelfId()
-    {
-        return shelf_id_;
-    }
-    
+    std::string GetPath() { return path_; }
+
+    ShelfId GetShelfId() { return shelf_id_; }
+
     // file must not be opened
-    ErrorCode Create(mode_t mode, size_t size=0);
+    ErrorCode Create(mode_t mode, size_t size = 0);
     ErrorCode Destroy();
-    ErrorCode Open(int flags);    
+    ErrorCode Open(int flags);
 
     // file must be opened
     ErrorCode Close();
-    // map a specific range 
-    ErrorCode Map(void *addr_hint, size_t length, int prot, int flags, loff_t offset, void **mapped_addr, bool register_fam_atomic=true);
+    // map a specific range
+    ErrorCode Map(void *addr_hint, size_t length, int prot, int flags,
+                  loff_t offset, void **mapped_addr,
+                  bool register_fam_atomic = true);
     // map the entire file and register itself with ShelfManager
     // requires a valid shelf_id_
     ErrorCode Map(void *addr_hint, void **mapped_addr);
 
     // work in both cases (opened or not opened)
     // unmap a specific range (used by the memory manager)
-    static ErrorCode Unmap(void *mapped_addr, size_t length, bool unoregister_fam_atomic=true);
+    static ErrorCode Unmap(void *mapped_addr, size_t length,
+                           bool unoregister_fam_atomic = true);
 
     // unmap the entire file and unregister itself with ShelfManager
     // requires a valid shelf_id_
@@ -83,19 +77,21 @@ public:
     ErrorCode Truncate(off_t length);
     ErrorCode Rename(char const *new_pathname);
     bool Exist();
-    size_t Size();        
+    size_t Size();
     ErrorCode GetPermission(mode_t *mode);
     ErrorCode SetPermission(mode_t mode);
 
-private:
+    ErrorCode MarkInvalid();
+    bool IsInvalid();
+
+  private:
     int fd_;
     std::string path_;
     ShelfId shelf_id_;
 
-    //DEBUG
+    // DEBUG
     void *addr_;
     size_t length_;
-    
 };
 
 } // namespace nvmm

--- a/src/shelf_mgmt/shelf_manager.h
+++ b/src/shelf_mgmt/shelf_manager.h
@@ -25,62 +25,72 @@
 #ifndef _NVMM_SHELF_MANAGER_H_
 #define _NVMM_SHELF_MANAGER_H_
 
-#include <mutex>
 #include <map>
-#include <unordered_map>
+#include <mutex>
 #include <stddef.h>
+#include <unordered_map>
 
+#include "nvmm/error_code.h"
 #include "nvmm/shelf_id.h"
 
-namespace nvmm{
+namespace nvmm {
 
 // the ShelfManager keeps two mappings:
 // - shelf ID => base ptr and length
-// - base ptr => shelf ID and length    
-// NOTE: to register for a shelf, the shelf must be mapped entirely (no partial mmap)
-// TODO: to unregister a shelf safely, we have to make sure the shelf is not being accessed
-// use reference counts???
-// TODO: should also store file handle    
-class ShelfManager
-{
-public:
+// - base ptr => shelf ID and length
+// NOTE: to register for a shelf, the shelf must be mapped entirely (no partial
+// mmap)
+// TODO: to unregister a shelf safely, we have to make sure the shelf is not
+// being accessed use reference counts???
+// TODO: should also store file handle
+class ShelfManager {
+  public:
+    static int64_t num_heap_instance;
     /*
       called by ShelfFile
     */
     // register a shelf's ID, base ptr, and length
     static void *RegisterShelf(ShelfId shelf_id, void *base, size_t length);
     // unregister a shelf's ID, base ptr, and length
-    // for now we only unregister a shelf when the shelf is being destroyed (deleted)
+    // for now we only unregister a shelf when the shelf is being destroyed
+    // (deleted)
     static void *UnregisterShelf(ShelfId shelf_id);
-    // check if a shelf is registered or not and return its base if it is registered
+    // check if a shelf is registered or not and return its base if it is
+    // registered
     static void *LookupShelf(ShelfId shelf_id);
-
     /*
       called by MemoryManager
     */
     // given a shelf's ID, return the base of the shelf
     static void *FindBase(ShelfId shelf_id);
-    // given a shelf's pathname and shelf ID, register it, map it, and return the base of the shelf
+    // given a shelf's pathname and shelf ID, register it, map it, and return
+    // the base of the shelf
     static void *FindBase(std::string path, ShelfId shelf_id);
-    // given a local pointer backed by a shelf, return the shelf's ID and its base pointer
+    // given a local pointer backed by a shelf, return the shelf's ID and its
+    // base pointer
     static ShelfId FindShelf(void *ptr, void *&base);
+    // Mark the entry in map_ and reverse_map_ for shelf_id as invalid
+    static ErrorCode MarkInvalid(ShelfId shelf_id);
+    // check if the given shelf is invalid
+    static bool IsInvalid(ShelfId shelf_id);
     // unmap everything, clear both mappings
     static void Reset();
 
-    
     static void Lock();
-    static void Unlock();    
+    static void Unlock();
 
-private:
-    static std::mutex map_mutex_; // guard concurrent access to map_ and rmap_ (more specifically,
-                                  // mapping/unmapping/finding shelves)
+  private:
+    static std::mutex
+        map_mutex_; // guard concurrent access to map_ and rmap_ (more
+                    // specifically, mapping/unmapping/finding shelves)
     // shelf ID => base ptr and length
-    static std::unordered_map<ShelfId, std::pair<void *, size_t>, ShelfId::Hash, ShelfId::Equal> map_;
+    static std::unordered_map<ShelfId, std::tuple<void *, size_t, bool>,
+                              ShelfId::Hash, ShelfId::Equal>
+        map_;
     // base ptr => shelf ID and length
-    static std::map<void*, std::pair<ShelfId, size_t>> reverse_map_;
-    
+    static std::map<void *, std::tuple<ShelfId, size_t, bool>> reverse_map_;
 };
 
 } // namespace nvmm
-    
+
 #endif

--- a/src/shelf_usage/shelf_region.cc
+++ b/src/shelf_usage/shelf_region.cc
@@ -26,9 +26,9 @@
 #include <stdint.h>
 #include <string>
 
-#include <fcntl.h> // for O_RDWR
 #include <assert.h> // for assert()
 #include <boost/filesystem.hpp>
+#include <fcntl.h> // for O_RDWR
 
 #include "nvmm/error_code.h"
 #include "shelf_mgmt/shelf_file.h"
@@ -40,80 +40,69 @@
 namespace nvmm {
 
 ShelfRegion::ShelfRegion(std::string pathname)
-    : is_open_{false}, shelf_{pathname}
-{
-}
+    : is_open_{false}, shelf_{pathname} {}
 
-ShelfRegion::~ShelfRegion()
-{
-    if (IsOpen() == true)
-    {
+ShelfRegion::~ShelfRegion() {
+    if (IsOpen() == true) {
         (void)Close();
     }
 }
 
-ErrorCode ShelfRegion::Create(size_t size)
-{
+ErrorCode ShelfRegion::Create(size_t size) {
     TRACE();
     assert(IsOpen() == false);
     assert(shelf_.Exist() == true);
-    
+
     // allocate memory for the shelf
     return shelf_.Truncate(size);
 }
 
-ErrorCode ShelfRegion::Resize(size_t size)
-{
+ErrorCode ShelfRegion::Resize(size_t size) {
     TRACE();
-    assert(IsOpen() ==true);
+    assert(IsOpen() == true);
 
     // allocate memory for the shelf
     return shelf_.Truncate(size);
 }
 
-ErrorCode ShelfRegion::Destroy()
-{
+ErrorCode ShelfRegion::Destroy() {
     TRACE();
     assert(IsOpen() == false);
     // truncate the size of the shelf file to 0
     // leave the deletion of the file to the caller
-    return shelf_.Truncate(0);
+    // return shelf_.Truncate(0);
+    // Destory will not anything other than checking if the region is not
+    // Open(). Deleting the file is callers responsibility
+    return NO_ERROR;
 }
 
-ErrorCode ShelfRegion::Verify()
-{
+ErrorCode ShelfRegion::Verify() {
     assert(IsOpen() == false);
     ErrorCode ret = NO_ERROR;
 
-    // TODO: check size == N*8GB???    
-    if (shelf_.Exist() == true)
-    {
+    // TODO: check size == N*8GB???
+    if (shelf_.Exist() == true) {
         ret = NO_ERROR;
-    }
-    else
-    {
+    } else {
         ret = SHELF_FILE_NOT_FOUND;
     }
 
     return ret;
 }
 
-ErrorCode ShelfRegion::Open(int flags)
-{
+ErrorCode ShelfRegion::Open(int flags) {
     TRACE();
     assert(IsOpen() == false);
 
     ErrorCode ret = NO_ERROR;
-    ret = Verify();    
-    if (ret != NO_ERROR)
-    {
+    ret = Verify();
+    if (ret != NO_ERROR) {
         return ret;
     }
 
     // open the shelf
     ret = shelf_.Open(flags);
-    if (ret != NO_ERROR)
-    {
+    if (ret != NO_ERROR) {
         return ret;
     }
 
@@ -121,58 +110,51 @@ ErrorCode ShelfRegion::Open(int flags)
     return NO_ERROR;
 }
 
-ErrorCode ShelfRegion::GetPermission(mode_t *mode)
-{
+ErrorCode ShelfRegion::GetPermission(mode_t *mode) {
     TRACE();
     if (IsOpen() == false) {
-      return SHELF_FILE_CLOSED; 
+        return SHELF_FILE_CLOSED;
     }
     return shelf_.GetPermission(mode);
 }
 
-ErrorCode ShelfRegion::SetPermission(mode_t mode)
-{
-   TRACE();
-   if (IsOpen() == false) {
-     return SHELF_FILE_CLOSED;
-   }
-   return shelf_.SetPermission(mode);
-
+ErrorCode ShelfRegion::SetPermission(mode_t mode) {
+    TRACE();
+    if (IsOpen() == false) {
+        return SHELF_FILE_CLOSED;
+    }
+    return shelf_.SetPermission(mode);
 }
 
-ErrorCode ShelfRegion::Close()
-{
+ErrorCode ShelfRegion::Close() {
     TRACE();
     assert(IsOpen() == true);
 
     ErrorCode ret = NO_ERROR;
     // close the shelf
     ret = shelf_.Close();
-    if (ret != NO_ERROR)
-    {
+    if (ret != NO_ERROR) {
         return ret;
     }
-        
+
     is_open_ = false;
     return NO_ERROR;
 }
 
-size_t ShelfRegion::Size()
-{
+size_t ShelfRegion::Size() {
     assert(IsOpen() == true);
     return shelf_.Size();
 }
- 
 
-ErrorCode ShelfRegion::Map(void *addr_hint, size_t length, int prot, int flags, loff_t offset, void **mapped_addr)
-{
+ErrorCode ShelfRegion::Map(void *addr_hint, size_t length, int prot, int flags,
+                           loff_t offset, void **mapped_addr) {
     TRACE();
     assert(IsOpen() == true);
-    return shelf_.Map(addr_hint, length, prot, flags, offset, mapped_addr, true);
+    return shelf_.Map(addr_hint, length, prot, flags, offset, mapped_addr,
+                      true);
 }
 
-ErrorCode ShelfRegion::Unmap(void *mapped_addr, size_t length)
-{
+ErrorCode ShelfRegion::Unmap(void *mapped_addr, size_t length) {
     TRACE();
     assert(IsOpen() == true);
     return shelf_.Unmap(mapped_addr, length, true);

--- a/src/shelf_usage/zone_shelf_heap.h
+++ b/src/shelf_usage/zone_shelf_heap.h
@@ -37,25 +37,22 @@ namespace nvmm {
 
 class Zone;
 
-class ShelfHeap
-{
-public:
+class ShelfHeap {
+  public:
     ShelfHeap() = delete;
     // the shelf file must already exist
     ShelfHeap(std::string pathname);
     ShelfHeap(std::string pathname, ShelfId shelf_id);
     ~ShelfHeap();
 
-    ErrorCode Create(size_t size, void *helper, size_t helper_size, size_t min_alloc_size);
+    ErrorCode Create(size_t size, void *helper, size_t helper_size,
+                     size_t min_alloc_size);
     ErrorCode Destroy();
     ErrorCode Verify();
     ErrorCode Recover();
     ErrorCode SetPermission(mode_t mode);
 
-    bool IsOpen() const
-    {
-        return is_open_;
-    }
+    bool IsOpen() const { return is_open_; }
 
     ErrorCode Open(void *helper, size_t helper_size);
     ErrorCode Close();
@@ -69,7 +66,7 @@ public:
     bool IsValidPtr(void *addr);
 
     void *OffsetToPtr(Offset offset) const;
-    Offset PtrToOffset(void *addr) const ;
+    Offset PtrToOffset(void *addr) const;
     size_t get_bitmap_offset();
 
     void Merge();
@@ -77,14 +74,18 @@ public:
     void OnlineRecover();
 
     void Stats();
-    ErrorCode Map(Offset offset, size_t size, void *addr_hint, int prot, void **mapped_addr);
+    ErrorCode Map(Offset offset, size_t size, void *addr_hint, int prot,
+                  void **mapped_addr);
     ErrorCode Unmap(Offset offset, void *mapped_addr, size_t size);
 
     static size_t get_header_size(size_t shelf_size, size_t min_obj_size);
 
-private:
-    ErrorCode OpenMapShelf(bool use_shelf_manager=false);
-    ErrorCode UnmapCloseShelf(bool use_shelf_manager=false, bool unregister=false);
+    ErrorCode MarkInvalid();
+
+  private:
+    ErrorCode OpenMapShelf(bool use_shelf_manager = false);
+    ErrorCode UnmapCloseShelf(bool use_shelf_manager = false,
+                              bool unregister = false);
     bool is_open_;
     ShelfFile shelf_;
     void *addr_;


### PR DESCRIPTION
Problem : While destroying the heap, background thread was crashing if multiple instances of heaps are open

Fix : 1] Mark the heap as invalid if the destroy is in progress, 
        2] Mark all the shelves belong that heap as invalid in shelf manager 
        3] Do the cleanup and exit from the background worker