### PR TITLE
Non Cache coherent access support for NVMM

### DIFF
--- a/include/nvmm/nvmm_fam_atomic.h
+++ b/include/nvmm/nvmm_fam_atomic.h
@@ -100,6 +100,20 @@ inline void fam_atomic_128_compare_and_store(int64_t* addr, int64_t oldval[2], i
     fam_atomic_128_compare_store((int64_t*) addr, (int64_t*) oldval, (int64_t*) newval, (int64_t*)result);
 }
 
+/*
+ * Inline function to use atomic function to read from FAM
+ */
+static inline uint64_t nvmm_read(uint64_t *addr) {
+    return (uint64_t)fam_atomic_u64_read(addr); 
+}
+
+/*
+ * Inline function to use atomic function to read from FAM
+ */
+static inline int64_t nvmm_read(int64_t *addr) {
+    return fam_atomic_64_read(addr); 
+}
+
 inline void explicit_memory_barrier() {
     asm volatile("" ::: "memory");
 }

--- a/src/common/root_shelf.cc
+++ b/src/common/root_shelf.cc
@@ -134,11 +134,11 @@ ErrorCode RootShelf::Create()
     cur+=size;
     memset(cur, 0, size);
 
-    // finally set the magic number
-    fam_atomic_u64_write((uint64_t*)addr, kMagicNum);
-
     // Make sure all updates are persisted     
     fam_persist(addr, kShelfSize);
+
+    // finally set the magic number
+    fam_atomic_u64_write((uint64_t*)addr, kMagicNum);
 
     //LOG(fatal) << "unregister fam atomic " << (uint64_t)addr;
     fam_atomic_unregister_region(addr, kShelfSize);


### PR DESCRIPTION
    Add an inline function nvmm_read to read all fam mapped variables.
    zoneheader structure to use nvmm_read. Use nvmm_read() for variables which needs
    atomic access in Non Cache coherent modes.
    Fix fam_persist to be before atomic operation in root_shelf.cc