### PR TITLE
Initialize is_invalid_ flag in EpochZoneHeap and other changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ endif(${result})
 #
 if(FAME) # FAME
   add_definitions(-DFAME)
+  add_definitions(-DNON_CACHE_COHERENT)
   set(TMPFS_PATH "/lfs")
   message(STATUS "LFS enabled")
   message(STATUS "Lfs location: ${TMPFS_PATH}")
@@ -67,6 +68,7 @@ endif()
 #
 if(LFSWORKAROUND)
   add_definitions(-DLFSWORKAROUND)
+  add_definitions(-DNON_CACHE_COHERENT)
 endif()
 
 if(LFS_BOOK_SIZE)

--- a/include/nvmm/nvmm_fam_atomic.h
+++ b/include/nvmm/nvmm_fam_atomic.h
@@ -104,14 +104,22 @@ inline void fam_atomic_128_compare_and_store(int64_t* addr, int64_t oldval[2], i
  * Inline function to use atomic function to read from FAM
  */
 static inline uint64_t nvmm_read(uint64_t *addr) {
+#ifdef NON_CACHE_COHERENT   
     return (uint64_t)fam_atomic_u64_read(addr); 
+#else
+    return (uint64_t)*addr;
+#endif
 }
 
 /*
  * Inline function to use atomic function to read from FAM
  */
 static inline int64_t nvmm_read(int64_t *addr) {
+#ifdef NON_CACHE_COHERENT
     return fam_atomic_64_read(addr); 
+#else
+    return (int64_t)*addr;
+#endif
 }
 
 inline void explicit_memory_barrier() {


### PR DESCRIPTION
     - Initialize is_invalid_ flag.
     - Add flag NON_CACHE_COHERENT
     - Unmap and close the region_ in Heap Destroy after writing gh_