### PR TITLE
Add Maximum heap size check before creating shelves

### DIFF
--- a/include/nvmm/error_code.h
+++ b/include/nvmm/error_code.h
@@ -1,5 +1,5 @@
 /*
- *  (c) Copyright 2016-2017 Hewlett Packard Enterprise Development Company LP.
+ *  (c) Copyright 2016-2020 Hewlett Packard Enterprise Development Company LP.
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Lesser General Public License as published by
@@ -123,6 +123,7 @@ enum ErrorCode {
     // memory manager (200-)
     ID_FOUND = 200, // this id is in use
     ID_NOT_FOUND,   // this id is available
+    ID_NOT_VALID,   // This id is not valid
     INVALID_PTR,
     MAP_POINTER_FAILED,
 

--- a/src/allocator/epoch_zone_heap.cc
+++ b/src/allocator/epoch_zone_heap.cc
@@ -1,5 +1,5 @@
 /*
- *  (c) Copyright 2016-2017 Hewlett Packard Enterprise Development Company LP.
+ *  (c) Copyright 2016-2020 Hewlett Packard Enterprise Development Company LP.
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Lesser General Public License as published by
@@ -44,6 +44,8 @@
 #include "nvmm/epoch_manager.h"
 
 #include "allocator/epoch_zone_heap.h"
+
+#include "common/common.h"
 
 namespace nvmm {
 
@@ -145,6 +147,11 @@ ErrorCode EpochZoneHeap::Create(size_t shelf_size, size_t min_alloc_size,
 
         // Round off the shelf size to next power of 2
         shelf_size = next_power_of_two(shelf_size);
+
+        // If shelf_size is greater than MAX_ZONE_SIZE return error
+        if (shelf_size > MAX_ZONE_SIZE) {
+          return HEAP_CREATE_FAILED;
+        }
 
         // create an empty pool
         ret = pool_.Create(shelf_size, mode);
@@ -280,6 +287,11 @@ ErrorCode EpochZoneHeap::Create(size_t shelf_size, size_t min_alloc_size,
 //
 ErrorCode EpochZoneHeap::Resize(size_t size) {
     TRACE();
+
+    if (size > MAX_ZONE_SIZE) {
+      return HEAP_RESIZE_FAILED;
+    }
+
     // TODO: Currently resize can be performed only on open heap
     if (IsOpen() != true) {
         LOG(error) << "Heap is not open";

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -1,5 +1,5 @@
 /*
- *  (c) Copyright 2016-2017 Hewlett Packard Enterprise Development Company LP.
+ *  (c) Copyright 2016-2020 Hewlett Packard Enterprise Development Company LP.
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Lesser General Public License as published by
@@ -39,6 +39,15 @@ static int const kVirtualPageSize = 64*1024;
  * Permission mask
  */
 #define PERM_MASK (S_IRWXU|S_IRWXG|S_IRWXO) /* 0777 */
+
+/*
+ * Maximum supported heap size
+ */
+#define KB 1024UL
+#define MB (KB * KB)
+#define GB (MB * KB)
+
+#define MAX_ZONE_SIZE (1024 * GB)
 
 /*
  * Round non-negative x up to the nearest multiple of positive

--- a/src/memory_manager.cc
+++ b/src/memory_manager.cc
@@ -402,6 +402,12 @@ ErrorCode MemoryManager::Impl_::CreateHeap(PoolId id, size_t size, size_t min_al
     assert(is_ready_ == true);
     assert(id > 0);
     ErrorCode ret = NO_ERROR;
+
+    // Check if poolId > kMaxPoolCount    
+    if (id >= Pool::kMaxPoolCount) {
+        return ID_NOT_VALID;
+    }
+
     Lock(id);
     if (GetType(id)!=PoolType::NONE)
     {

--- a/src/shelf_usage/zone.cc
+++ b/src/shelf_usage/zone.cc
@@ -1,5 +1,5 @@
 /*
- *  (c) Copyright 2016-2017 Hewlett Packard Enterprise Development Company LP.
+ *  (c) Copyright 2016-2020 Hewlett Packard Enterprise Development Company LP.
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Lesser General Public License as published by
@@ -89,11 +89,6 @@ inline uint64_t next_power_of_two(uint64_t n)
 
 #define BYTE 8UL
 #define ATOMIC_SIZE 64UL
-#define KB 1024UL
-#define MB (KB * KB)
-#define GB (MB * KB)
-//#define TB (GB * KB)
-#define MAX_ZONE_SIZE (1024 * GB)
 #define MIN_OBJ_SIZE 64
 #define MAX_LEVEL_PER_ZONE power_of_two(MAX_ZONE_SIZE / MIN_OBJ_SIZE)
 //TODO: Add zoneheader size ????


### PR DESCRIPTION
    Maximum heap size check was present in zone.cc after all the shelfs
    were created. Add it in epoch_zone_heap.cc